### PR TITLE
remove instructions to create new Twitch Access Token every 60 days

### DIFF
--- a/docs/guides/video-games.md
+++ b/docs/guides/video-games.md
@@ -30,12 +30,6 @@ tracking.
 6. Set the `video_games.*` configuration variables in the environment as
 	described in the [configuration](/README.md#-configuration-options) docs.
 
-## Important notes
-
-- The Twitch Access Token is only active for **60 days**. Please create a new
-	client secret using the above steps when your token has expired. More
-	information [here](https://api-docs.igdb.com/#4-my-accesstoken-stopped-working-why).
-	
 ## Conclusion
 
 After following these steps, you should have video game integration working


### PR DESCRIPTION
IGDB documentation about 60 days token expiry referees to the tokens acquired by `https://id.twitch.tv/oauth2/token`, not the `Client ID` and `Client Secret`, and you correctly generate new token here https://github.com/IgnisDa/ryot/blob/f0d4d2c021a69695e60dbe280d2e34b993dd8414/apps/backend/src/utils.rs#L334-L338 so there is no need for any user action after submitting initial `Client ID` and `Client Secret`.

PS: I like you project very much