### PR TITLE
fix(frontend): apply box-shadow and border-radius to same elements

### DIFF
--- a/apps/frontend/src/lib/components/MediaItem.tsx
+++ b/apps/frontend/src/lib/components/MediaItem.tsx
@@ -161,11 +161,15 @@ export const BaseDisplayItem = (props: {
 						placeholder={<Text size={60}>{props.imagePlaceholder}</Text>}
 						style={{ cursor: "pointer" }}
 						alt={`Image for ${props.name}`}
-						sx={(_t) => ({
-							":hover": { boxShadow: "0 0 15px black" },
-							transitionProperty: "transform",
-							transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
-							transitionDuration: "150ms",
+						styles={() => ({
+							image: {
+								transitionProperty: "transform",
+								transitionTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
+								transitionDuration: "150ms",
+								'&:hover': {
+									boxShadow: "0 0 15px black",
+								}
+							}
 						})}
 					/>
 					{props.topRight}


### PR DESCRIPTION
Having the box-shadow and border-radius on two different elements resulted in a small gap being visible between a rectangular box shadow and an image with rounded corners. The `sx` prop does not allow targeting the underlying `Image` component directly (which is what the `radius` prop is targeting), but the mantine Styles API (used via the `styles` prop) does.

**Before**
![Screen Shot 2023-08-13 at 11 29 08](https://github.com/IgnisDa/ryot/assets/8725013/23493914-28ee-4a8f-9507-ad211715ff61)

**After**
![Screen Shot 2023-08-13 at 11 28 59](https://github.com/IgnisDa/ryot/assets/8725013/870483cc-e63f-41e9-b54b-e38e201da45d)