### PR TITLE
fix(frontend): fix media item images always displayed as carousel

### DIFF
--- a/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
+++ b/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
@@ -24,23 +24,28 @@ export default function ({
 					[t.fn.largerThan("md")]: { width: "35%" },
 				})}
 			>
-				{posterImages.length > 0 ? (
-					<Carousel withIndicators={posterImages.length > 1} w={300}>
-						{[...posterImages, ...backdropImages].map((url, idx) => (
-							<Carousel.Slide key={url} data-image-idx={idx}>
-								<Image
-									src={url}
-									radius={"lg"}
-									imageProps={{ loading: "lazy" }}
-								/>
-							</Carousel.Slide>
-						))}
-					</Carousel>
-				) : (
-					<Box w={300}>
-						<Image withPlaceholder height={400} radius={"lg"} />
-					</Box>
-				)}
+        {posterImages.length > 1 ? (
+          <Carousel withIndicators={posterImages.length > 1} w={300}>
+            {[...posterImages, ...backdropImages].map((url, idx) => (
+              <Carousel.Slide key={url} data-image-idx={idx}>
+                <Image
+                  src={url}
+                  radius={"lg"}
+                  imageProps={{ loading: "lazy" }}
+                />
+              </Carousel.Slide>
+            ))}
+          </Carousel>
+        ) : (
+          <Box w={300}>
+            <Image
+              src={posterImages[0] || backdropImages[0]}
+              withPlaceholder
+              height={400}
+              radius={"lg"}
+            />
+          </Box>
+        )}
 				{externalLink ? (
 					<Badge
 						id="data-source"


### PR DESCRIPTION
Some media item only have one image available, a carousel is not needed on those cases. This PR aims to fix that.
Before : 
![image](https://github.com/IgnisDa/ryot/assets/11031685/61421f5e-7569-4423-8aa2-b65028204973)

After : 
![image](https://github.com/IgnisDa/ryot/assets/11031685/ea10266b-5f1f-4677-b003-a1afbef797cc)
