### PR TITLE
fix(frontend): add spacing to h3 titles on people item

### DIFF
--- a/apps/frontend/src/pages/media/people/index.tsx
+++ b/apps/frontend/src/pages/media/people/index.tsx
@@ -115,7 +115,7 @@ const Page: NextPageWithLayout = () => {
 								<Stack>
 									{creatorDetails.data.contents.map((role) => (
 										<Box key={role.name}>
-											<Title order={3} align="center">
+											<Title order={3} mb="xs" align="center">
 												{role.name}
 											</Title>
 											<SimpleGrid


### PR DESCRIPTION
Add a margin bottom "xs" to Title of people item (the same value as the margin on media item h3 titles)
Before: 
![image](https://github.com/IgnisDa/ryot/assets/11031685/30aaa820-d38d-4400-96aa-fd2c883f5d7c)

After:
![image](https://github.com/IgnisDa/ryot/assets/11031685/10ba3a5d-dbdb-479b-871c-53534faa4101)
