### PR TITLE
perf(frontend): lazy load carousel images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,7 +4317,7 @@ checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "ryot"
-version = "2.7.2"
+version = "2.7.3"
 dependencies = [
  "anyhow",
  "apalis",

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryot"
-version = "2.7.2"
+version = "2.7.3"
 edition = "2021"
 repository = "https://github.com/IgnisDa/ryot"
 license = "GPL-V3"

--- a/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
+++ b/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
@@ -1,6 +1,25 @@
 import { Carousel } from "@mantine/carousel";
 import { Anchor, Badge, Box, Flex, Image, Stack, Text } from "@mantine/core";
 import { IconExternalLink } from "@tabler/icons-react";
+import { useState } from "react";
+
+function getSurroundingElements<T>(array: T[], element: number): number[] {
+	if (array.length === 1) {
+		return [0];
+	}
+
+	const lastIndex = array.length - 1;
+
+	if (element === 0) {
+		return [lastIndex, element, element + 1];
+	}
+
+	if (element === lastIndex) {
+		return [element - 1, element, 0];
+	}
+
+	return [element - 1, element, element + 1];
+}
 
 export default function ({
 	children,
@@ -13,6 +32,9 @@ export default function ({
 	backdropImages: string[];
 	externalLink?: { source: string; href?: string | null };
 }) {
+	const images = [...posterImages, ...backdropImages];
+	const [activeImageId, setActiveImageId] = useState<number>(0);
+
 	return (
 		<Flex direction={{ base: "column", md: "row" }} gap={"lg"}>
 			<Box
@@ -24,28 +46,30 @@ export default function ({
 					[t.fn.largerThan("md")]: { width: "35%" },
 				})}
 			>
-        {posterImages.length > 1 ? (
-          <Carousel withIndicators={posterImages.length > 1} w={300}>
-            {[...posterImages, ...backdropImages].map((url, idx) => (
-              <Carousel.Slide key={url} data-image-idx={idx}>
-                <Image
-                  src={url}
-                  radius={"lg"}
-                  imageProps={{ loading: "lazy" }}
-                />
-              </Carousel.Slide>
-            ))}
-          </Carousel>
-        ) : (
-          <Box w={300}>
-            <Image
-              src={posterImages[0] || backdropImages[0]}
-              withPlaceholder
-              height={400}
-              radius={"lg"}
-            />
-          </Box>
-        )}
+				{posterImages.length > 1 ? (
+					<Carousel withIndicators={posterImages.length > 1} w={300} onSlideChange={setActiveImageId}>
+						{images.map((url, idx) => (
+							<Carousel.Slide key={url} data-image-idx={idx}>
+								{getSurroundingElements(images, activeImageId).includes(idx) && (
+									<Image
+										src={url}
+										radius={"lg"}
+										imageProps={{ loading: "lazy" }}
+									/>
+								)}
+							</Carousel.Slide>
+						))}
+					</Carousel>
+				) : (
+					<Box w={300}>
+						<Image
+							src={posterImages[0] || backdropImages[0]}
+							withPlaceholder
+							height={400}
+							radius={"lg"}
+						/>
+					</Box>
+				)}
 				{externalLink ? (
 					<Badge
 						id="data-source"

--- a/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
+++ b/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
@@ -26,10 +26,10 @@ export default function ({
 	const [activeImageId, setActiveImageId] = useState<number>(0);
 
 	return (
-		<Flex direction={{ base: "column", md: "row" }} gap={"lg"}>
+		<Flex direction={{ base: "column", md: "row" }} gap="lg">
 			<Box
 				id="images-container"
-				pos={"relative"}
+				pos="relative"
 				sx={(t) => ({
 					width: "100%",
 					flex: "none",
@@ -60,14 +60,14 @@ export default function ({
 							src={posterImages[0] || backdropImages[0]}
 							withPlaceholder
 							height={400}
-							radius={"lg"}
+							radius="lg"
 						/>
 					</Box>
 				)}
 				{externalLink ? (
 					<Badge
 						id="data-source"
-						pos={"absolute"}
+						pos="absolute"
 						size="lg"
 						top={10}
 						left={10}

--- a/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
+++ b/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
@@ -4,20 +4,10 @@ import { IconExternalLink } from "@tabler/icons-react";
 import { useState } from "react";
 
 function getSurroundingElements<T>(array: T[], element: number): number[] {
-	if (array.length === 1) {
-		return [0];
-	}
-
+	if (array.length === 1) return [0];
 	const lastIndex = array.length - 1;
-
-	if (element === 0) {
-		return [lastIndex, element, element + 1];
-	}
-
-	if (element === lastIndex) {
-		return [element - 1, element, 0];
-	}
-
+	if (element === 0) return [lastIndex, element, element + 1];
+	if (element === lastIndex) return [element - 1, element, 0];
 	return [element - 1, element, element + 1];
 }
 
@@ -47,10 +37,16 @@ export default function ({
 				})}
 			>
 				{posterImages.length > 1 ? (
-					<Carousel withIndicators={posterImages.length > 1} w={300} onSlideChange={setActiveImageId}>
+					<Carousel
+						withIndicators={posterImages.length > 1}
+						w={300}
+						onSlideChange={setActiveImageId}
+					>
 						{images.map((url, idx) => (
 							<Carousel.Slide key={url} data-image-idx={idx}>
-								{getSurroundingElements(images, activeImageId).includes(idx) && (
+								{getSurroundingElements(images, activeImageId).includes(
+									idx,
+								) && (
 									<Image
 										src={url}
 										radius={"lg"}

--- a/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
+++ b/apps/frontend/src/lib/components/MediaDetailsLayout.tsx
@@ -44,15 +44,13 @@ export default function ({
 					>
 						{images.map((url, idx) => (
 							<Carousel.Slide key={url} data-image-idx={idx}>
-								{getSurroundingElements(images, activeImageId).includes(
-									idx,
-								) && (
+								{getSurroundingElements(images, activeImageId).includes(idx) ? (
 									<Image
 										src={url}
-										radius={"lg"}
+										radius="lg"
 										imageProps={{ loading: "lazy" }}
 									/>
-								)}
+								) : null}
 							</Carousel.Slide>
 						))}
 					</Carousel>


### PR DESCRIPTION
The Carousel component doesn't have any support for lazy loading inner content. This can mean tens of megabytes of data transfer occur for some shows due to having a large number of images available. A simple workaround for this is to only load the visible image component, along with its immediate neighbors. Loading the immediate neighbors ensures the user experience remains smooth (not preloading those images can cause some elements to jump around as the image loads in).

This was just an idea that popped into my head as a quick workaround after the discussion in https://github.com/IgnisDa/ryot/issues/263#issuecomment-1680295643. Happy to shelve this idea if you'd prefer a cleaner solution.