### PR TITLE
Add target arch

### DIFF
--- a/apps/backend/ci/build-app.sh
+++ b/apps/backend/ci/build-app.sh
@@ -4,5 +4,6 @@ set -euxo pipefail
 
 export RUST_TARGET_TRIPLE=$(eval "echo \$RUST_TARGET_TRIPLE_$TARGETARCH")
 
+rustup target add $RUST_TARGET_TRIPLE
 cargo build --profile dist --bin ryot --target ${RUST_TARGET_TRIPLE}
 cp -R /app/target/${RUST_TARGET_TRIPLE}/dist/ryot /app/ryot


### PR DESCRIPTION
No idea why we need this but not before. I guess it is because we always pull the latest version of image `lukemathwalker/cargo-chef`. I suggest you to pin it to a more specific version.