### PR TITLE
use glibc instead of musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,7 +4461,7 @@ checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "ryot"
-version = "4.0.8-beta.1"
+version = "4.0.8-beta.2"
 dependencies = [
  "anyhow",
  "apalis",

--- a/apps/backend/Cargo.toml
+++ b/apps/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryot"
-version = "4.0.8-beta.1"
+version = "4.0.8-beta.2"
 edition = "2021"
 repository = "https://github.com/IgnisDa/ryot"
 license = "GPL-V3"


### PR DESCRIPTION
In this `dockerfile`, we switch the compilation target from `musl` to `gnu`. In addition, the `x86_64` target which was previously compiled with `gcc` is now switched to `clang` so we can have a more uniform experience between two targets.

After #544, we will switch the base image for the backend to `gcr.io/distroless/static-debian12` which is even lighter than `alpine` and has `glibc`.