### PR TITLE
fix LengthVec import in rs_utils test

### DIFF
--- a/libs/rs-utils/src/length_vec.rs
+++ b/libs/rs-utils/src/length_vec.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 ///
 /// # Examples
 /// ```
-/// use length_vec::LengthVec;
+/// use rs_utils::LengthVec;
 ///
 /// let mut length_vec = LengthVec::new(5);
 /// length_vec.push(1);


### PR DESCRIPTION
without this cargo test does not build properly:

error message:
```
error[E0432]: unresolved import `length_vec`
 --> libs/rs-utils/src/length_vec.rs:13:5
  |
3 | use length_vec::LengthVec;
  |     ^^^^^^^^^^ use of undeclared crate or module `length_vec`

error: aborting due to 1 previous error

For more information about this error, try `rustc --explain E0432`.
Couldn't compile the test.

```