### PR TITLE
Fix: No longer panic on invalid TZ string

### DIFF
--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -153,8 +153,16 @@ async fn main() -> Result<()> {
     let perform_core_application_job_storage = create_storage(pool.clone()).await;
 
     let tz: chrono_tz::Tz = env::var("TZ")
-        .map(|s| s.parse().unwrap())
-        .unwrap_or_else(|_| chrono_tz::Etc::GMT);
+        .ok()
+        .and_then(|s| {
+            if let Ok(tz_parsed) = s.parse::<chrono_tz::Tz>() {
+                Some(tz_parsed)
+            } else {
+                tracing::info!("Invalid timezone: {}", s);
+                None
+            }
+        })
+        .unwrap_or_else(|| chrono_tz::Etc::GMT);
     tracing::info!("Using timezone: {}", tz);
 
     let app_services = create_app_services(


### PR DESCRIPTION
When starting Ryot with `$TZ` set to an invalid timezone string (in my case a typo; `America/New_York` vs `America/New_york`) the backend panics without explanation due to the `.unwrap()` call at the end of 156. This patch allows the backend to inform the user of the invalid timezone string and gracefully fall back to GMT instead of panicking. 