### PR TITLE
Add Emby Integration

### DIFF
--- a/apps/backend/src/integrations.rs
+++ b/apps/backend/src/integrations.rs
@@ -1,4 +1,4 @@
-use std::future::Future;
+use std::{fs::metadata, future::Future};
 
 use anyhow::{anyhow, bail, Result};
 use async_graphql::Result as GqlResult;
@@ -50,6 +50,124 @@ pub struct IntegrationService {
 impl IntegrationService {
     pub fn new(db: &DatabaseConnection) -> Self {
         Self { db: db.clone() }
+    }
+
+    pub async fn emby_progress(&self, payload: &str) -> Result<IntegrationMediaSeen> {
+        mod models {
+            use super::*;
+
+            #[derive(Serialize, Deserialize, Debug, Clone)]
+            #[serde(rename_all = "PascalCase")]
+            pub struct EmbyWebhookPlaybackInfoPayload {
+                pub position_ticks: Option<Decimal>,
+            }
+            #[derive(Serialize, Deserialize, Debug, Clone)]
+            #[serde(rename_all = "PascalCase")]
+            pub struct EmbyWebhookItemProviderIdsPayload {
+                pub tmdb: Option<String>,
+            }
+            #[derive(Serialize, Deserialize, Debug, Clone)]
+            #[serde(rename_all = "PascalCase")]
+            pub struct EmbyWebhookItemPayload {
+                pub run_time_ticks: Option<Decimal>,
+                #[serde(rename = "Type")]
+                pub item_type: String,
+                pub provider_ids: EmbyWebhookItemProviderIdsPayload,
+                #[serde(rename = "ParentIndexNumber")]
+                pub season_number: Option<i32>,
+                #[serde(rename = "IndexNumber")]
+                pub episode_number: Option<i32>,
+                #[serde(rename = "Name")]
+                pub episode_name:  Option<String>,
+                pub series_name: Option<String>,
+            }
+            #[derive(Serialize, Deserialize, Debug, Clone)]
+            #[serde(rename_all = "PascalCase")]
+            pub struct EmbyWebhookPayload {
+                pub event: Option<String>,
+                pub item: EmbyWebhookItemPayload,
+                pub series: Option<EmbyWebhookItemPayload>,
+                pub playback_info: EmbyWebhookPlaybackInfoPayload,
+            }
+        }
+
+        let payload = serde_json::from_str::<models::EmbyWebhookPayload>(payload)?;
+
+        let identifier = if let Some(id) = payload.item.provider_ids.tmdb.as_ref() {
+            Some(id.clone())
+        } else {
+            payload
+                .series
+                .as_ref()
+                .and_then(|s| s.provider_ids.tmdb.clone())
+        };
+
+        if payload.item.run_time_ticks.is_none() {
+            bail!("No run time associated with this media")
+        }
+        if payload.playback_info.position_ticks.is_none() {
+            bail!("No position associated with this media")
+        }
+
+        let runtime = payload.item.run_time_ticks.unwrap();
+        let position = payload.playback_info.position_ticks.unwrap();
+
+        let (identifier, lot) = match payload.item.item_type.as_str() {
+            "Episode" => {
+                if payload.item.episode_name.is_none() {
+                    bail!("No episode name associated with this media")
+                }
+
+                if payload.item.series_name.is_none() {
+                    bail!("No series name associated with this media")
+                }
+
+                let series_name = payload.item.series_name.unwrap();
+                let episode_name = payload.item.episode_name.unwrap();
+
+                let db_show = Metadata::find()
+                    .filter(metadata::Column::Lot.eq(MediaLot::Show))
+                    .filter(metadata::Column::Source.eq(MediaSource::Tmdb))
+                    .filter(
+                        Expr::col(metadata::Column::Title)
+                        .ilike(ilike_sql(&series_name))
+                    )
+                    .filter(
+                        Expr::expr(Func::cast_as(
+                            Expr::col(metadata::Column::ShowSpecifics), 
+                            Alias::new("text"),
+                        ))
+                        .ilike(ilike_sql(&episode_name)),
+                    )
+                    .one(&self.db)
+                    .await?;
+                
+                if db_show.is_none() {
+                    bail!("No show found with Series Name {} and Episode Name {}", series_name, episode_name);
+                }
+
+                (db_show.unwrap().identifier, MediaLot::Show)
+            },
+            "Movie" => {
+                if identifier.is_none() {
+                    bail!("No TMDb ID associated with this media")
+                }
+
+                (identifier.unwrap().to_owned(), MediaLot::Movie)
+            },
+            _ => bail!("Only movies and shows supported"),
+        };
+
+        Ok(IntegrationMediaSeen {
+            identifier,
+            lot,
+            source: MediaSource::Tmdb,
+            progress: position / runtime * dec!(100),
+            show_season_number: payload.item.season_number,
+            show_episode_number: payload.item.episode_number,
+            provider_watched_on: Some("Emby".to_string()),
+            ..Default::default()
+        })
     }
 
     pub async fn jellyfin_progress(&self, payload: &str) -> Result<IntegrationMediaSeen> {

--- a/apps/backend/src/integrations.rs
+++ b/apps/backend/src/integrations.rs
@@ -1,4 +1,4 @@
-use std::{fs::metadata, future::Future};
+use std::future::Future;
 
 use anyhow::{anyhow, bail, Result};
 use async_graphql::Result as GqlResult;

--- a/apps/backend/src/miscellaneous.rs
+++ b/apps/backend/src/miscellaneous.rs
@@ -5883,6 +5883,7 @@ impl MiscellaneousService {
         let service = self.get_integration_service();
         let maybe_progress_update = match integration.source {
             IntegrationSource::Kodi => service.kodi_progress(&payload).await,
+            IntegrationSource::Emby => service.emby_progress(&payload).await,
             IntegrationSource::Jellyfin => service.jellyfin_progress(&payload).await,
             IntegrationSource::Plex => {
                 let specifics = integration.clone().source_specifics.unwrap();

--- a/libs/database/src/definitions.rs
+++ b/libs/database/src/definitions.rs
@@ -448,6 +448,7 @@ pub enum IntegrationLot {
 pub enum IntegrationSource {
     Audiobookshelf,
     Jellyfin,
+    Emby,
     Plex,
     Kodi,
 }

--- a/libs/generated/src/graphql/backend/graphql.ts
+++ b/libs/generated/src/graphql/backend/graphql.ts
@@ -714,6 +714,7 @@ export enum IntegrationLot {
 export enum IntegrationSource {
   Audiobookshelf = 'AUDIOBOOKSHELF',
   Jellyfin = 'JELLYFIN',
+  Emby = 'EMBY',
   Kodi = 'KODI',
   Plex = 'PLEX'
 }


### PR DESCRIPTION
Added emby integration this could possibly be integrated into the jellyfin integration but there are a decent amount of differences so we should probably keep them separate.

I am planning to add emby as an import source as well but this should probably be done in the future in a separate PR.