### PR TITLE
Fix missing "ps" terminal command on app crash/exit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ LABEL org.opencontainers.image.source="https://github.com/IgnisDa/ryot"
 ENV FRONTEND_UMAMI_SCRIPT_URL="https://umami.diptesh.me/script.js"
 ENV FRONTEND_UMAMI_WEBSITE_ID="5ecd6915-d542-4fda-aa5f-70f09f04e2e0"
 COPY --from=caddy:2.7.5 /usr/bin/caddy /usr/local/bin/caddy
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates procps && rm -rf /var/lib/apt/lists/*
 RUN npm install --global concurrently@8.2.2 && concurrently --version
 RUN useradd -m -u 1001 ryot
 WORKDIR /home/ryot


### PR DESCRIPTION
Fixes errors with invocations of "ps" terminal command...
Current master/latest contains some code/libraries that invoke "ps" command under certain circumstances (perhaps specific architectures or such).

Example of error this meant to solve:
```
[backend] 2024-08-06T01:06:23.929688Z  INFO sea_orm_migration::migrator: Applying all pending migrations
[backend] 2024-08-06T01:06:23.935904Z  INFO sea_orm_migration::migrator: No pending migrations
[backend] thread 'main' panicked at apps/backend/src/main.rs:159:28:
[backend] called `Result::unwrap()` on an `Err` value: ParseError(())
[backend] BACKEND_PORT=5000 /usr/local/bin/ryot exited with code 101
node:events:492
      throw er; // Unhandled 'error' event
      ^

Error: spawn ps ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at onErrorNT (node:internal/child_process:484:16)
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn ps',
  path: 'ps',
  spawnargs: [ '-o', 'pid', '--no-headers', '--ppid', 17 ]
}

Node.js v20.10.0
```

PS: it may not solve the problem of the core reason of why app itself crashed in my particular example, but it will allow app to handle shutdown gracefully in case of shutdown/crash flow.