### PR TITLE
Fixed bug in review score rendering

### DIFF
--- a/apps/frontend/app/components/media.tsx
+++ b/apps/frontend/app/components/media.tsx
@@ -601,12 +601,9 @@ export const MetadataDisplayItem = (props: {
 					<Group gap={4}>
 						<IconStarFilled size={12} style={{ color: "#EBE600FF" }} />
 						<Text c="white" size="xs" fw="bold" pr={4}>
-							{match(userPreferences.general.reviewScale)
-								.with(UserReviewScale.OutOfFive, () =>
-									Number.parseFloat(averageRating.toString()).toFixed(1),
-								)
-								.with(UserReviewScale.OutOfHundred, () => averageRating)
-								.exhaustive()}
+							{Number(averageRating) % 1 === 0
+								? Math.round(Number(averageRating)).toString()
+								: Number(averageRating).toFixed(1)}
 							{userPreferences.general.reviewScale === UserReviewScale.OutOfFive
 								? undefined
 								: " %"}


### PR DESCRIPTION
When rendering the review score it was possible to create repeating numbers

![image](https://github.com/user-attachments/assets/42dbdb2a-3718-42ca-aee4-a03e40ab92ec)

With the provided fix it will render as a normal number with no decimal if its a whole number.

![image](https://github.com/user-attachments/assets/df90792b-310a-419b-a893-bffb0dedddf3)
![image](https://github.com/user-attachments/assets/342bf30b-4cb2-416f-90ce-a081466c94a7)
