### PR TITLE
Addressed bug with Finished Condition during background tasks

### DIFF
--- a/apps/backend/src/miscellaneous.rs
+++ b/apps/backend/src/miscellaneous.rs
@@ -2733,7 +2733,7 @@ impl MiscellaneousService {
                     if !seen_history.is_empty() {
                         new_reasons.insert(UserToMediaReason::Seen);
                     }
-                    if is_finished {
+                    if !seen_history.is_empty() && is_finished {
                         new_reasons.insert(UserToMediaReason::Finished);
                     }
                 } else if ute.person_id.is_some() || ute.metadata_group_id.is_some() {


### PR DESCRIPTION
There is a bug in the following condition:
- Import a manga and place it into a collection without downloading metadata
- Perform background tasks

This will result in the manga being marked as finished due to the episode count being 0. Modifying the condition to ensure that we arent marking something as finished without any watch history addresses this problem. This issue is extremely prevalent in the `Sync to Owned collection` function.