### PR TITLE
Introduced media status for anilist

### DIFF
--- a/crates/providers/src/anilist/media_details.graphql
+++ b/crates/providers/src/anilist/media_details.graphql
@@ -6,6 +6,7 @@ query MediaDetailsQuery($id: Int!) {
       native
       romaji
     }
+    status
     airingSchedule {
       nodes {
         airingAt

--- a/crates/providers/src/anilist/mod.rs
+++ b/crates/providers/src/anilist/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use chrono::NaiveDate;

--- a/crates/providers/src/anilist/mod.rs
+++ b/crates/providers/src/anilist/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt::Display;
-
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use chrono::NaiveDate;
@@ -122,17 +120,15 @@ impl NonMediaAnilistService {
     }
 }
 
-impl Display for media_details_query::MediaStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
-            media_details_query::MediaStatus::FINISHED => "Finished".to_string(),
-            media_details_query::MediaStatus::RELEASING => "Ongoing".to_string(),
-            media_details_query::MediaStatus::NOT_YET_RELEASED => "Not Yet Released".to_string(),
-            media_details_query::MediaStatus::CANCELLED => "Canceled".to_string(),
-            media_details_query::MediaStatus::HIATUS => "Hiatus".to_string(),
-            _ => "Unknown".to_string(),
-        };
-        write!(f, "{}", str)
+fn media_status_string(status: Option<media_details_query::MediaStatus>) -> Option<String>
+{
+    match status {
+        Some(media_details_query::MediaStatus::FINISHED) => Some("Finished".to_string()),
+        Some(media_details_query::MediaStatus::RELEASING) => Some("Ongoing".to_string()),
+        Some(media_details_query::MediaStatus::NOT_YET_RELEASED) => Some("Not Yet Released".to_string()),
+        Some(media_details_query::MediaStatus::CANCELLED) => Some("Canceled".to_string()),
+        Some(media_details_query::MediaStatus::HIATUS) => Some("Hiatus".to_string()),
+        _ => None,
     }
 }
 
@@ -700,7 +696,6 @@ async fn media_details(
         title.romaji,
         preferred_language,
     );
-    let status = details.status.unwrap();
     Ok(MediaDetails {
         title,
         identifier: details.id.to_string(),
@@ -721,7 +716,7 @@ async fn media_details(
         provider_rating: score,
         group_identifiers: vec![],
         s3_images: vec![],
-        production_status: Some(status.to_string()),
+        production_status: media_status_string(details.status),
         original_language: None,
         ..Default::default()
     })

--- a/crates/providers/src/anilist/mod.rs
+++ b/crates/providers/src/anilist/mod.rs
@@ -130,7 +130,7 @@ impl Display for media_details_query::MediaStatus {
             media_details_query::MediaStatus::NOT_YET_RELEASED => "Not Yet Released".to_string(),
             media_details_query::MediaStatus::CANCELLED => "Canceled".to_string(),
             media_details_query::MediaStatus::HIATUS => "Hiatus".to_string(),
-            _ => "Unknown".to_string()
+            _ => "Unknown".to_string(),
         };
         write!(f, "{}", str)
     }

--- a/crates/providers/src/anilist/mod.rs
+++ b/crates/providers/src/anilist/mod.rs
@@ -6,7 +6,6 @@ use config::AnilistPreferredLanguage;
 use enums::{MediaLot, MediaSource};
 use graphql_client::{GraphQLQuery, Response};
 use itertools::Itertools;
-use media_details_query::MediaStatus;
 use models::{
     AnimeAiringScheduleSpecifics, AnimeSpecifics, MangaSpecifics, MediaDetails,
     MetadataImageForMediaDetails, MetadataPerson, MetadataSearchItem, MetadataVideo,
@@ -122,14 +121,14 @@ impl NonMediaAnilistService {
     }
 }
 
-impl Display for MediaStatus {
+impl Display for media_details_query::MediaStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
-            MediaStatus::FINISHED => "FINISHED".to_string(),
-            MediaStatus::RELEASING => "RELEASING".to_string(),
-            MediaStatus::NOT_YET_RELEASED => "NOT_YET_RELEASED".to_string(),
-            MediaStatus::CANCELLED => "CANCELLED".to_string(),
-            MediaStatus::HIATUS => "HIATUS".to_string(),
+            media_details_query::MediaStatus::FINISHED => "FINISHED".to_string(),
+            media_details_query::MediaStatus::RELEASING => "RELEASING".to_string(),
+            media_details_query::MediaStatus::NOT_YET_RELEASED => "NOT_YET_RELEASED".to_string(),
+            media_details_query::MediaStatus::CANCELLED => "CANCELLED".to_string(),
+            media_details_query::MediaStatus::HIATUS => "HIATUS".to_string(),
             _ => "Unknown".to_string()
         };
         write!(f, "{}", str)

--- a/crates/providers/src/anilist/mod.rs
+++ b/crates/providers/src/anilist/mod.rs
@@ -124,11 +124,11 @@ impl NonMediaAnilistService {
 impl Display for media_details_query::MediaStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
-            media_details_query::MediaStatus::FINISHED => "FINISHED".to_string(),
-            media_details_query::MediaStatus::RELEASING => "RELEASING".to_string(),
-            media_details_query::MediaStatus::NOT_YET_RELEASED => "NOT_YET_RELEASED".to_string(),
-            media_details_query::MediaStatus::CANCELLED => "CANCELLED".to_string(),
-            media_details_query::MediaStatus::HIATUS => "HIATUS".to_string(),
+            media_details_query::MediaStatus::FINISHED => "Finished".to_string(),
+            media_details_query::MediaStatus::RELEASING => "Ongoing".to_string(),
+            media_details_query::MediaStatus::NOT_YET_RELEASED => "Not Yet Released".to_string(),
+            media_details_query::MediaStatus::CANCELLED => "Canceled".to_string(),
+            media_details_query::MediaStatus::HIATUS => "Hiatus".to_string(),
             _ => "Unknown".to_string()
         };
         write!(f, "{}", str)


### PR DESCRIPTION
This works but for some reason my IDE is confused about the existence of `use media_details_query::MediaStatus;` so maybe I need to add something else too. Not sure because it compiles and works.

![image](https://github.com/user-attachments/assets/61337cff-3f15-4e68-b598-c815f726f5d9)

see: https://katsurin.com/docs/anilist-node/global.html#MediaStatus