### PR TITLE
Resolved bug where we assumed timezone

### DIFF
--- a/crates/services/miscellaneous/src/lib.rs
+++ b/crates/services/miscellaneous/src/lib.rs
@@ -3238,7 +3238,7 @@ impl MiscellaneousService {
                 ProgressUpdateInput {
                     metadata_id: id,
                     progress: Some(progress),
-                    date: Some(Utc::now().date_naive()),
+                    date: Some(get_current_date(&self.timezone)),
                     show_season_number: pu.show_season_number,
                     show_episode_number: pu.show_episode_number,
                     podcast_episode_number: pu.podcast_episode_number,


### PR DESCRIPTION
We assumed the user was using UTC as the timezone so when we perform the check in progressUpdateInput depending on the timezone we sometimes incorrectly mark things as InThePast Rather Than Update for progress state