### PR TITLE
frontend: fix hardcoded port

### DIFF
--- a/apps/frontend/app/lib/utilities.server.ts
+++ b/apps/frontend/app/lib/utilities.server.ts
@@ -38,7 +38,8 @@ import {
 	toastKey,
 } from "~/lib/generals";
 
-export const API_URL = process.env.API_URL || "http://127.0.0.1:8000/backend";
+const API_PORT = process.env.PORT || 8000;
+export const API_URL = process.env.API_URL || `http://127.0.0.1:${API_PORT}/backend`;
 
 class AuthenticatedGraphQLClient extends GraphQLClient {
 	async authenticatedRequest<T, V extends Variables = Variables>(


### PR DESCRIPTION
When running this in nomad, I noticed that not specifying the mapped port (i.e. getting a random one) caused the frontend to error with the following image and logs:

![image](https://github.com/user-attachments/assets/f74ab695-e5da-4454-b01a-3c9d68e3dc26)

<details>
  <summary>Relevant logs</summary>

```log
2024-12-22T08:17:09.351911362+00:00 stdout F [frontend] GET / 302 - - 55.257 ms
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend] TypeError: fetch failed
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     at fetch (/home/ryot/node_modules/undici/index.js:112:13)
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     at processTicksAndRejections (node:internal/process/task_queues:95:5)
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     at file:///home/ryot/node_modules/graphql-request/src/legacy/helpers/runRequest.ts:191:10
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     at runRequest (file:///home/ryot/node_modules/graphql-request/src/legacy/helpers/runRequest.ts:72:25)
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     at AuthenticatedGraphQLClient.request (file:///home/ryot/node_modules/graphql-request/src/legacy/classes/GraphQLClient.ts:131:22) {
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]   [cause]: Error: connect ECONNREFUSED 127.0.0.1:8000
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]       at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1595:16) {
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     errno: -111,
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     code: 'ECONNREFUSED',
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     syscall: 'connect',
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     address: '127.0.0.1',
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]     port: 8000
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend]   }
2024-12-22T08:17:09.473476117+00:00 stdout F [frontend] }
2024-12-22T08:17:09.483648221+00:00 stdout F [frontend] [Error: Unexpected Server Error]
```
</details>

This commit removes a hard-coded port to the backend from the frontend, which caused issues when changing the port using the `PORT` environment variable, as shown in the official docs.