### PR TITLE
Move recommendations fetching to client side

### DIFF
--- a/apps/frontend/app/components/common.tsx
+++ b/apps/frontend/app/components/common.tsx
@@ -1458,6 +1458,7 @@ export const DisplayListDetailsAndRefresh = (props: {
 
 export const ExpireCacheKeyButton = (props: {
 	cacheId: string;
+	onSubmit?: () => void;
 	confirmationText?: string;
 }) => {
 	const submit = useConfirmSubmit();
@@ -1467,6 +1468,7 @@ export const ExpireCacheKeyButton = (props: {
 		<Form
 			replace
 			method="POST"
+			onSubmit={props.onSubmit}
 			action={withQuery($path("/actions"), {
 				intent: "expireCacheKey",
 				[redirectToQueryParam]: location.pathname,
@@ -1481,7 +1483,10 @@ export const ExpireCacheKeyButton = (props: {
 					const form = e.currentTarget.form;
 					if (form) {
 						e.preventDefault();
-						openConfirmationModal(props.confirmationText, () => submit(form));
+						openConfirmationModal(props.confirmationText, () => {
+							submit(form);
+							props.onSubmit?.();
+						});
 					}
 				}}
 			>

--- a/apps/frontend/app/components/common.tsx
+++ b/apps/frontend/app/components/common.tsx
@@ -1457,7 +1457,7 @@ export const DisplayListDetailsAndRefresh = (props: {
 };
 
 export const ExpireCacheKeyButton = (props: {
-	cacheId: string;
+	cacheId?: string;
 	onSubmit?: () => void;
 	confirmationText?: string;
 }) => {

--- a/apps/frontend/app/lib/common.tsx
+++ b/apps/frontend/app/lib/common.tsx
@@ -415,8 +415,8 @@ const fitnessQueryKeys = createQueryKeys("fitness", {
 });
 
 const userQueryKeys = createQueryKeys("user", {
-	userPendingNotifications: () => ({
-		queryKey: ["userPendingNotifications"],
+	userMetadataRecommendations: () => ({
+		queryKey: ["userMetadataRecommendations"],
 	}),
 });
 

--- a/apps/frontend/app/routes/_dashboard._index.tsx
+++ b/apps/frontend/app/routes/_dashboard._index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@ryot/generated/graphql/backend/graphql";
 import { isNumber, parseSearchQuery, zodBoolAsString } from "@ryot/ts-utils";
 import { IconInfoCircle, IconPlayerPlay } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
 import CryptoJS from "crypto-js";
 import type { ReactNode } from "react";
 import { redirect, useLoaderData } from "react-router";
@@ -44,7 +45,6 @@ import {
 	serverGqlService,
 } from "~/lib/utilities.server";
 import type { Route } from "./+types/_dashboard._index";
-import { useQuery } from "@tanstack/react-query";
 
 const searchParamsSchema = z.object({
 	ignoreLandingPath: zodBoolAsString.optional(),

--- a/apps/frontend/app/routes/_dashboard._index.tsx
+++ b/apps/frontend/app/routes/_dashboard._index.tsx
@@ -210,7 +210,7 @@ export default function Page() {
 							<Section key={v} lot={v}>
 								<SectionTitleWithRefreshIcon
 									text="Recommendations"
-									cacheId={userMetadataRecommendationsQuery.data?.cacheId ?? ""}
+									cacheId={userMetadataRecommendationsQuery.data?.cacheId}
 									confirmationText="Are you sure you want to refresh the recommendations?"
 									onRefresh={async () => {
 										await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -264,7 +264,7 @@ export default function Page() {
 
 const SectionTitleWithRefreshIcon = (props: {
 	text: string;
-	cacheId: string;
+	cacheId?: string;
 	onRefresh?: () => void;
 	confirmationText?: string;
 }) => {

--- a/apps/frontend/app/routes/_dashboard._index.tsx
+++ b/apps/frontend/app/routes/_dashboard._index.tsx
@@ -212,6 +212,10 @@ export default function Page() {
 									text="Recommendations"
 									cacheId={userMetadataRecommendationsQuery.data?.cacheId ?? ""}
 									confirmationText="Are you sure you want to refresh the recommendations?"
+									onRefresh={async () => {
+										await new Promise((resolve) => setTimeout(resolve, 1000));
+										userMetadataRecommendationsQuery.refetch();
+									}}
 								/>
 								{userMetadataRecommendationsQuery.data ? (
 									<>
@@ -261,6 +265,7 @@ export default function Page() {
 const SectionTitleWithRefreshIcon = (props: {
 	text: string;
 	cacheId: string;
+	onRefresh?: () => void;
 	confirmationText?: string;
 }) => {
 	return (
@@ -268,6 +273,7 @@ const SectionTitleWithRefreshIcon = (props: {
 			<SectionTitle text={props.text} />
 			<ExpireCacheKeyButton
 				cacheId={props.cacheId}
+				onSubmit={() => props.onRefresh?.()}
 				confirmationText={props.confirmationText}
 			/>
 		</Group>


### PR DESCRIPTION
- Changed cacheId prop in ExpireCacheKeyButton and SectionTitleWithRefreshIcon components to be optional.
- Adjusted related component usage in the dashboard to reflect the updated prop definition.

Fixes #1297.