### PR TITLE
Allow custom start and end time while updating progress

### DIFF
--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/new-progress-form.tsx
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/new-progress-form.tsx
@@ -62,10 +62,11 @@ export const MetadataNewProgressUpdateForm = ({
 			watchTime,
 			common,
 			updates,
-			metadataToUpdate,
 			metadataDetails,
+			metadataToUpdate,
+			startDateFormatted,
+			finishDateFormatted,
 			currentDateFormatted,
-			selectedDateFormatted: finishDateFormatted,
 		});
 
 		const change: MetadataProgressUpdateChange = match(watchTime)

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/new-progress-form.tsx
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/new-progress-form.tsx
@@ -16,7 +16,10 @@ import { AnimeForm } from "./media-types/anime-form";
 import { MangaForm } from "./media-types/manga-form";
 import { PodcastForm } from "./media-types/podcast-form";
 import { ShowForm } from "./media-types/show-form";
-import { processBulkUpdates } from "./utils/bulk-update-handlers";
+import {
+	createCustomDatesCompletedChange,
+	processBulkUpdates,
+} from "./utils/bulk-update-handlers";
 import {
 	CustomDatePicker,
 	ProviderSelect,
@@ -84,40 +87,13 @@ export const MetadataNewProgressUpdateForm = ({
 					},
 				},
 			}))
-			.with(WatchTimes.CustomDates, () => {
-				if (startDateFormatted && finishDateFormatted) {
-					return {
-						createNewCompleted: {
-							startedAndFinishedOnDate: {
-								...common,
-								startedOn: startDateFormatted,
-								timestamp: finishDateFormatted,
-							},
-						},
-					};
-				}
-				if (startDateFormatted) {
-					return {
-						createNewCompleted: {
-							startedOnDate: {
-								...common,
-								timestamp: startDateFormatted,
-							},
-						},
-					};
-				}
-				if (finishDateFormatted) {
-					return {
-						createNewCompleted: {
-							finishedOnDate: {
-								...common,
-								timestamp: finishDateFormatted,
-							},
-						},
-					};
-				}
-				throw new Error("At least one date must be provided for CustomDates");
-			})
+			.with(WatchTimes.CustomDates, () =>
+				createCustomDatesCompletedChange({
+					startDateFormatted,
+					finishDateFormatted,
+					commonFields: common,
+				}),
+			)
 			.with(WatchTimes.IDontRemember, () => ({
 				createNewCompleted: { withoutDates: common },
 			}))

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -12,7 +12,8 @@ const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
 		history,
 		watchTime,
 		currentDateFormatted,
-		selectedDateFormatted,
+		startDateFormatted,
+		finishDateFormatted,
 		common,
 		updates,
 	} = context;
@@ -50,17 +51,43 @@ const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
 						},
 					}))
 					.with(WatchTimes.CustomDates, () => {
-						if (!selectedDateFormatted)
-							throw new Error("Selected date is undefined");
-						return {
-							createNewCompleted: {
-								finishedOnDate: {
-									...common,
-									animeEpisodeNumber: i,
-									timestamp: selectedDateFormatted,
+						if (startDateFormatted && finishDateFormatted) {
+							return {
+								createNewCompleted: {
+									startedAndFinishedOnDate: {
+										...common,
+										animeEpisodeNumber: i,
+										startedOn: startDateFormatted,
+										timestamp: finishDateFormatted,
+									},
 								},
-							},
-						};
+							};
+						}
+						if (startDateFormatted) {
+							return {
+								createNewCompleted: {
+									startedOnDate: {
+										...common,
+										animeEpisodeNumber: i,
+										timestamp: startDateFormatted,
+									},
+								},
+							};
+						}
+						if (finishDateFormatted) {
+							return {
+								createNewCompleted: {
+									finishedOnDate: {
+										...common,
+										animeEpisodeNumber: i,
+										timestamp: finishDateFormatted,
+									},
+								},
+							};
+						}
+						throw new Error(
+							"At least one date must be provided for CustomDates",
+						);
 					})
 					.with(WatchTimes.IDontRemember, () => ({
 						createNewCompleted: {
@@ -83,7 +110,8 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 		history,
 		watchTime,
 		currentDateFormatted,
-		selectedDateFormatted,
+		startDateFormatted,
+		finishDateFormatted,
 		common,
 		updates,
 	} = context;
@@ -137,17 +165,43 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 							},
 						}))
 						.with(WatchTimes.CustomDates, () => {
-							if (!selectedDateFormatted)
-								throw new Error("Selected date is undefined");
-							return {
-								createNewCompleted: {
-									finishedOnDate: {
-										...common,
-										mangaVolumeNumber: i,
-										timestamp: selectedDateFormatted,
+							if (startDateFormatted && finishDateFormatted) {
+								return {
+									createNewCompleted: {
+										startedAndFinishedOnDate: {
+											...common,
+											mangaVolumeNumber: i,
+											startedOn: startDateFormatted,
+											timestamp: finishDateFormatted,
+										},
 									},
-								},
-							};
+								};
+							}
+							if (startDateFormatted) {
+								return {
+									createNewCompleted: {
+										startedOnDate: {
+											...common,
+											mangaVolumeNumber: i,
+											timestamp: startDateFormatted,
+										},
+									},
+								};
+							}
+							if (finishDateFormatted) {
+								return {
+									createNewCompleted: {
+										finishedOnDate: {
+											...common,
+											mangaVolumeNumber: i,
+											timestamp: finishDateFormatted,
+										},
+									},
+								};
+							}
+							throw new Error(
+								"At least one date must be provided for CustomDates",
+							);
 						})
 						.with(WatchTimes.IDontRemember, () => ({
 							createNewCompleted: {
@@ -195,17 +249,43 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 								},
 							}))
 							.with(WatchTimes.CustomDates, () => {
-								if (!selectedDateFormatted)
-									throw new Error("Selected date is undefined");
-								return {
-									createNewCompleted: {
-										finishedOnDate: {
-											...common,
-											mangaChapterNumber: i.toString(),
-											timestamp: selectedDateFormatted,
+								if (startDateFormatted && finishDateFormatted) {
+									return {
+										createNewCompleted: {
+											startedAndFinishedOnDate: {
+												...common,
+												mangaChapterNumber: i.toString(),
+												startedOn: startDateFormatted,
+												timestamp: finishDateFormatted,
+											},
 										},
-									},
-								};
+									};
+								}
+								if (startDateFormatted) {
+									return {
+										createNewCompleted: {
+											startedOnDate: {
+												...common,
+												mangaChapterNumber: i.toString(),
+												timestamp: startDateFormatted,
+											},
+										},
+									};
+								}
+								if (finishDateFormatted) {
+									return {
+										createNewCompleted: {
+											finishedOnDate: {
+												...common,
+												mangaChapterNumber: i.toString(),
+												timestamp: finishDateFormatted,
+											},
+										},
+									};
+								}
+								throw new Error(
+									"At least one date must be provided for CustomDates",
+								);
 							})
 							.with(WatchTimes.IDontRemember, () => ({
 								createNewCompleted: {
@@ -230,7 +310,8 @@ const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
 		history,
 		watchTime,
 		currentDateFormatted,
-		selectedDateFormatted,
+		startDateFormatted,
+		finishDateFormatted,
 		common,
 		updates,
 	} = context;
@@ -302,18 +383,46 @@ const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
 							},
 						}))
 						.with(WatchTimes.CustomDates, () => {
-							if (!selectedDateFormatted)
-								throw new Error("Selected date is undefined");
-							return {
-								createNewCompleted: {
-									finishedOnDate: {
-										...common,
-										timestamp: selectedDateFormatted,
-										showSeasonNumber: currentEpisode.seasonNumber,
-										showEpisodeNumber: currentEpisode.episodeNumber,
+							if (startDateFormatted && finishDateFormatted) {
+								return {
+									createNewCompleted: {
+										startedAndFinishedOnDate: {
+											...common,
+											showSeasonNumber: currentEpisode.seasonNumber,
+											showEpisodeNumber: currentEpisode.episodeNumber,
+											startedOn: startDateFormatted,
+											timestamp: finishDateFormatted,
+										},
 									},
-								},
-							};
+								};
+							}
+							if (startDateFormatted) {
+								return {
+									createNewCompleted: {
+										startedOnDate: {
+											...common,
+											showSeasonNumber: currentEpisode.seasonNumber,
+											showEpisodeNumber: currentEpisode.episodeNumber,
+											timestamp: startDateFormatted,
+										},
+									},
+								};
+							}
+							if (finishDateFormatted) {
+								return {
+									createNewCompleted: {
+										finishedOnDate: {
+											...common,
+											showSeasonNumber: currentEpisode.seasonNumber,
+											showEpisodeNumber: currentEpisode.episodeNumber,
+											timestamp: finishDateFormatted,
+										},
+									},
+								};
+							}
+							throw new Error(
+								"At least one date must be provided for CustomDates",
+							);
 						})
 						.with(WatchTimes.IDontRemember, () => ({
 							createNewCompleted: {
@@ -338,7 +447,8 @@ const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
 		history,
 		watchTime,
 		currentDateFormatted,
-		selectedDateFormatted,
+		startDateFormatted,
+		finishDateFormatted,
 		common,
 		updates,
 	} = context;
@@ -383,17 +493,43 @@ const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
 							},
 						}))
 						.with(WatchTimes.CustomDates, () => {
-							if (!selectedDateFormatted)
-								throw new Error("Selected date is undefined");
-							return {
-								createNewCompleted: {
-									finishedOnDate: {
-										...common,
-										timestamp: selectedDateFormatted,
-										podcastEpisodeNumber: episode.number,
+							if (startDateFormatted && finishDateFormatted) {
+								return {
+									createNewCompleted: {
+										startedAndFinishedOnDate: {
+											...common,
+											podcastEpisodeNumber: episode.number,
+											startedOn: startDateFormatted,
+											timestamp: finishDateFormatted,
+										},
 									},
-								},
-							};
+								};
+							}
+							if (startDateFormatted) {
+								return {
+									createNewCompleted: {
+										startedOnDate: {
+											...common,
+											podcastEpisodeNumber: episode.number,
+											timestamp: startDateFormatted,
+										},
+									},
+								};
+							}
+							if (finishDateFormatted) {
+								return {
+									createNewCompleted: {
+										finishedOnDate: {
+											...common,
+											podcastEpisodeNumber: episode.number,
+											timestamp: finishDateFormatted,
+										},
+									},
+								};
+							}
+							throw new Error(
+								"At least one date must be provided for CustomDates",
+							);
 						})
 						.with(WatchTimes.IDontRemember, () => ({
 							createNewCompleted: {

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -5,7 +5,7 @@ import { match } from "ts-pattern";
 import { WatchTimes } from "../../../types";
 import type { BulkUpdateContext } from "./form-types";
 
-export const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
+const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
 	const {
 		metadataDetails,
 		metadataToUpdate,
@@ -76,7 +76,7 @@ export const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-export const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
+const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 	const {
 		metadataDetails,
 		metadataToUpdate,
@@ -223,7 +223,7 @@ export const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-export const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
+const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
 	const {
 		metadataDetails,
 		metadataToUpdate,
@@ -331,7 +331,7 @@ export const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-export const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
+const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
 	const {
 		metadataDetails,
 		metadataToUpdate,

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -87,10 +87,10 @@ const createUpdateChange = (input: CreateUpdateChangeInput) => {
 		}))
 		.with(WatchTimes.CustomDates, () =>
 			createCustomDatesCompletedChange({
-				startDateFormatted: input.startDateFormatted,
-				finishDateFormatted: input.finishDateFormatted,
 				commonFields: input.common,
 				additionalFields: input.fields,
+				startDateFormatted: input.startDateFormatted,
+				finishDateFormatted: input.finishDateFormatted,
 			}),
 		)
 		.with(WatchTimes.IDontRemember, () => ({

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -101,7 +101,7 @@ const createUpdateChange = (input: CreateUpdateChangeInput) => {
 		.exhaustive();
 };
 
-const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
+const handleAnimeBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Anime &&
 		context.metadataToUpdate.animeAllEpisodesBefore &&
@@ -130,7 +130,7 @@ const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
+const handleMangaBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Manga &&
 		context.metadataToUpdate.mangaAllChaptersOrVolumesBefore
@@ -206,7 +206,7 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
+const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Show &&
 		context.metadataToUpdate.showAllEpisodesBefore &&
@@ -270,7 +270,7 @@ const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
+const handlePodcastBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Podcast &&
 		context.metadataToUpdate.podcastAllEpisodesBefore &&
@@ -308,7 +308,7 @@ const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
 	}
 };
 
-export const processBulkUpdates = (context: BulkUpdateContext): void => {
+export const processBulkUpdates = (context: BulkUpdateContext) => {
 	handleAnimeBulkUpdates(context);
 	handleMangaBulkUpdates(context);
 	handleShowBulkUpdates(context);

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -49,7 +49,7 @@ export const handleAnimeBulkUpdates = (context: BulkUpdateContext): void => {
 							},
 						},
 					}))
-					.with(WatchTimes.CustomDate, () => {
+					.with(WatchTimes.CustomDates, () => {
 						if (!selectedDateFormatted)
 							throw new Error("Selected date is undefined");
 						return {
@@ -136,7 +136,7 @@ export const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 								},
 							},
 						}))
-						.with(WatchTimes.CustomDate, () => {
+						.with(WatchTimes.CustomDates, () => {
 							if (!selectedDateFormatted)
 								throw new Error("Selected date is undefined");
 							return {
@@ -194,7 +194,7 @@ export const handleMangaBulkUpdates = (context: BulkUpdateContext): void => {
 									},
 								},
 							}))
-							.with(WatchTimes.CustomDate, () => {
+							.with(WatchTimes.CustomDates, () => {
 								if (!selectedDateFormatted)
 									throw new Error("Selected date is undefined");
 								return {
@@ -301,7 +301,7 @@ export const handleShowBulkUpdates = (context: BulkUpdateContext): void => {
 								},
 							},
 						}))
-						.with(WatchTimes.CustomDate, () => {
+						.with(WatchTimes.CustomDates, () => {
 							if (!selectedDateFormatted)
 								throw new Error("Selected date is undefined");
 							return {
@@ -382,7 +382,7 @@ export const handlePodcastBulkUpdates = (context: BulkUpdateContext): void => {
 								},
 							},
 						}))
-						.with(WatchTimes.CustomDate, () => {
+						.with(WatchTimes.CustomDates, () => {
 							if (!selectedDateFormatted)
 								throw new Error("Selected date is undefined");
 							return {

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/common-elements.tsx
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/common-elements.tsx
@@ -40,20 +40,38 @@ export const WatchTimeSelect = ({
 };
 
 interface CustomDatePickerProps {
-	selectedDate: Date | null;
-	onDateChange: (date: Date | null) => void;
+	startDate: Date | null;
+	finishDate: Date | null;
+	onStartDateChange: (date: Date | null) => void;
+	onFinishDateChange: (date: Date | null) => void;
 }
 
-export const CustomDatePicker = ({ onDateChange }: CustomDatePickerProps) => {
+export const CustomDatePicker = ({
+	startDate,
+	finishDate,
+	onStartDateChange,
+	onFinishDateChange,
+}: CustomDatePickerProps) => {
 	return (
-		<DateTimePicker
-			required
-			clearable
-			dropdownType="modal"
-			maxDate={new Date()}
-			label="Enter exact date"
-			onChange={(e) => onDateChange(e ? new Date(e) : null)}
-		/>
+		<>
+			<DateTimePicker
+				clearable
+				value={startDate}
+				label="Started on"
+				dropdownType="modal"
+				maxDate={finishDate || new Date()}
+				onChange={(e) => onStartDateChange(e ? new Date(e) : null)}
+			/>
+			<DateTimePicker
+				clearable
+				value={finishDate}
+				label="Finished on"
+				dropdownType="modal"
+				maxDate={new Date()}
+				minDate={startDate || undefined}
+				onChange={(e) => onFinishDateChange(e ? new Date(e) : null)}
+			/>
+		</>
 	);
 };
 

--- a/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/form-types.ts
+++ b/apps/frontend/app/components/dashboard/forms/metadata-progress-update/utils/form-types.ts
@@ -31,8 +31,9 @@ export interface BulkUpdateContext {
 	history: History;
 	watchTime: WatchTimes;
 	currentDateFormatted: string;
+	startDateFormatted: string | null;
+	finishDateFormatted: string | null;
 	metadataToUpdate: UpdateProgressData;
-	selectedDateFormatted: string | null;
 	updates: MetadataProgressUpdateInput[];
 	common: MetadataProgressUpdateCommonInput;
 	metadataDetails: MetadataDetailsQuery["metadataDetails"];

--- a/apps/frontend/app/components/dashboard/types.ts
+++ b/apps/frontend/app/components/dashboard/types.ts
@@ -8,7 +8,7 @@ import type { ThreePointSmileyRating } from "~/lib/common";
 export enum WatchTimes {
 	JustCompletedNow = "Just Completed Now",
 	IDontRemember = "I don't remember",
-	CustomDate = "Custom Date",
+	CustomDates = "Custom Dates",
 	JustStartedIt = "Just Started It",
 }
 

--- a/apps/frontend/app/lib/state/fitness.ts
+++ b/apps/frontend/app/lib/state/fitness.ts
@@ -111,9 +111,7 @@ export const useGetSetAtIndex = (exerciseIdx: number, setIdx: number) => {
 	return exercise?.sets[setIdx];
 };
 
-export const getDefaultWorkout = (
-	fitnessEntity: FitnessAction,
-): InProgressWorkout => {
+export const getDefaultWorkout = (fitnessEntity: FitnessAction) => {
 	const date = dayjsLib().add(1, "second");
 	return {
 		images: [],
@@ -125,7 +123,7 @@ export const getDefaultWorkout = (
 		currentAction: fitnessEntity,
 		durations: [{ from: date.toISOString() }],
 		name: `${getTimeOfDay(date.hour())} Workout`,
-	};
+	} as InProgressWorkout;
 };
 
 export const getExerciseDetailsQuery = (exerciseId: string) =>

--- a/tests/backend-api/src/setup/globalSetup.ts
+++ b/tests/backend-api/src/setup/globalSetup.ts
@@ -8,7 +8,7 @@ import {
 // We store the started services in a closure to make them available to the teardown function.
 let services: StartedServices | undefined;
 
-export async function setup(): Promise<() => Promise<void>> {
+export async function setup() {
 	console.log("[GlobalSetup] Starting all services for tests...");
 	try {
 		services = await startAllServices();

--- a/tests/backend-api/src/setup/testOrchestrator.ts
+++ b/tests/backend-api/src/setup/testOrchestrator.ts
@@ -41,7 +41,7 @@ const DB_USER = "testuser";
 const DB_PASSWORD = "testpassword";
 const DB_NAME = "testdb";
 
-async function createMinioBucket(endpoint: string): Promise<void> {
+async function createMinioBucket(endpoint: string) {
 	const s3Client = new S3Client({
 		endpoint,
 		region: "us-east-1",
@@ -107,7 +107,7 @@ async function waitForHealthCheck(
 	url: string,
 	maxRetries = 10,
 	retryDelay = 500,
-): Promise<void> {
+) {
 	for (let i = 0; i < maxRetries; i++) {
 		try {
 			const response = await fetch(url);
@@ -211,7 +211,7 @@ async function startBackendProcess(
 	});
 }
 
-export async function startAllServices(): Promise<StartedServices> {
+export async function startAllServices() {
 	const network = await new Network().start();
 
 	console.log("[Orchestrator] Starting containers in parallel...");
@@ -283,9 +283,7 @@ export async function startAllServices(): Promise<StartedServices> {
 	};
 }
 
-export async function stopAllServices(
-	services: StartedServices | undefined,
-): Promise<void> {
+export async function stopAllServices(services: StartedServices | undefined) {
 	if (!services) {
 		return;
 	}


### PR DESCRIPTION
Fixes #1437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced date selection in progress update forms, allowing users to specify both a start date and a finish date.
  * Updated custom date picker to support separate start and finish dates with logical date range enforcement.

* **Style**
  * Improved UI for date selection with clearer labeling and validation for start and finish dates.

* **Chores**
  * Renamed relevant options to reflect support for multiple dates in custom date selection.
  * Internalized bulk update handlers and updated related naming for consistency.
  * Simplified function signatures by removing explicit type annotations in backend test setup and service orchestration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->