### PR TITLE
Remove 'MarkPlayed' event and streamline progress calculation in Jellyfin webhook

### DIFF
--- a/apps/docs/src/integrations/jellyfin-sink.md
+++ b/apps/docs/src/integrations/jellyfin-sink.md
@@ -16,4 +16,4 @@ to be installed and active in Jellyfin.
     - Webhook URL => `<paste_url_copied>`
     - Payload format => `Default`
     - Listen to events only for => Choose your user
-    - Events => `Play`, `Pause`, `Resume`, `Stop`, `Progress` and `MarkPlayed`
+    - Events => `Play`, `Pause`, `Resume`, `Stop` and `Progress`

--- a/crates/services/integration/src/sink/jellyfin.rs
+++ b/crates/services/integration/src/sink/jellyfin.rs
@@ -75,23 +75,18 @@ pub async fn sink_progress(payload: String) -> Result<Option<ImportResult>> {
         ..Default::default()
     };
 
-    match payload.event.unwrap_or_default().as_str() {
-        "MarkPlayed" => {}
-        _ => {
-            let runtime = payload
-                .item
-                .run_time_ticks
-                .ok_or_else(|| anyhow!("No run time associated with this media"))?;
+    let runtime = payload
+        .item
+        .run_time_ticks
+        .ok_or_else(|| anyhow!("No run time associated with this media"))?;
 
-            let position = payload
-                .session
-                .as_ref()
-                .and_then(|s| s.play_state.position_ticks.as_ref())
-                .ok_or_else(|| anyhow!("No position associated with this media"))?;
+    let position = payload
+        .session
+        .as_ref()
+        .and_then(|s| s.play_state.position_ticks.as_ref())
+        .ok_or_else(|| anyhow!("No position associated with this media"))?;
 
-            seen_item.progress = Some(position / runtime * dec!(100));
-        }
-    }
+    seen_item.progress = Some(position / runtime * dec!(100));
 
     Ok(Some(ImportResult {
         completed: vec![ImportCompletedItem::Metadata(ImportOrExportMetadataItem {


### PR DESCRIPTION
Fixes #1490.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Jellyfin integration instructions to remove the need to select the "MarkPlayed" event in webhook plugin settings. Only "Play", "Pause", "Resume", "Stop", and "Progress" events are now required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->