### PR TITLE
Allow marking only current season as watched

### DIFF
--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
@@ -1,7 +1,10 @@
 import { Paper, SegmentedControl, Select, Text } from "@mantine/core";
 import { MediaLot } from "@ryot/generated/graphql/backend/graphql";
 import { produce } from "immer";
-import { ShowMarkingMode, useMetadataProgressUpdate } from "~/lib/state/media";
+import {
+	UpdateProgressShowMarkingMode,
+	useMetadataProgressUpdate,
+} from "~/lib/state/media";
 import type { MediaFormProps } from "../utils/form-types";
 
 export const ShowForm = (props: MediaFormProps) => {
@@ -59,20 +62,24 @@ export const ShowForm = (props: MediaFormProps) => {
 					size="xs"
 					fullWidth
 					data={[
-						{ label: "All", value: ShowMarkingMode.All },
-						{ label: "Season", value: ShowMarkingMode.Season },
+						{ label: "All", value: UpdateProgressShowMarkingMode.All },
+						{ label: "Season", value: UpdateProgressShowMarkingMode.Season },
 					]}
-					value={metadataToUpdate.showMarkingMode || ShowMarkingMode.All}
+					value={
+						metadataToUpdate.showMarkingMode ||
+						UpdateProgressShowMarkingMode.All
+					}
 					onChange={(value) => {
 						updateMetadataToUpdate(
 							produce(metadataToUpdate, (draft) => {
-								draft.showMarkingMode = value as ShowMarkingMode;
+								draft.showMarkingMode = value as UpdateProgressShowMarkingMode;
 							}),
 						);
 					}}
 				/>
 				<Text size="xs" c="dimmed" mt="xs">
-					{metadataToUpdate.showMarkingMode === ShowMarkingMode.Season
+					{metadataToUpdate.showMarkingMode ===
+					UpdateProgressShowMarkingMode.Season
 						? "Mark all unseen episodes in this season before this"
 						: "Mark all unseen episodes before this"}
 				</Text>

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
@@ -1,7 +1,7 @@
-import { Checkbox, Select } from "@mantine/core";
+import { Paper, SegmentedControl, Select, Text } from "@mantine/core";
 import { MediaLot } from "@ryot/generated/graphql/backend/graphql";
 import { produce } from "immer";
-import { useMetadataProgressUpdate } from "~/lib/state/media";
+import { ShowMarkingMode, useMetadataProgressUpdate } from "~/lib/state/media";
 import type { MediaFormProps } from "../utils/form-types";
 
 export const ShowForm = (props: MediaFormProps) => {
@@ -54,18 +54,29 @@ export const ShowForm = (props: MediaFormProps) => {
 						})) || []
 				}
 			/>
-			<Checkbox
-				size="xs"
-				label="Mark all unseen episodes before this as seen"
-				defaultChecked={metadataToUpdate.showAllEpisodesBefore}
-				onChange={(e) => {
-					updateMetadataToUpdate(
-						produce(metadataToUpdate, (draft) => {
-							draft.showAllEpisodesBefore = e.target.checked;
-						}),
-					);
-				}}
-			/>
+			<Paper p="xs" withBorder>
+				<SegmentedControl
+					size="xs"
+					fullWidth
+					data={[
+						{ label: "All", value: ShowMarkingMode.All },
+						{ label: "Season", value: ShowMarkingMode.Season },
+					]}
+					value={metadataToUpdate.showMarkingMode || ShowMarkingMode.All}
+					onChange={(value) => {
+						updateMetadataToUpdate(
+							produce(metadataToUpdate, (draft) => {
+								draft.showMarkingMode = value as ShowMarkingMode;
+							}),
+						);
+					}}
+				/>
+				<Text size="xs" c="dimmed" mt="xs">
+					{metadataToUpdate.showMarkingMode === ShowMarkingMode.Season
+						? "Mark all unseen episodes in this season before this"
+						: "Mark all unseen episodes before this"}
+				</Text>
+			</Paper>
 		</>
 	);
 };

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
@@ -1,10 +1,7 @@
-import { Paper, SegmentedControl, Select, Text } from "@mantine/core";
+import { Checkbox, Select } from "@mantine/core";
 import { MediaLot } from "@ryot/generated/graphql/backend/graphql";
 import { produce } from "immer";
-import {
-	UpdateProgressShowMarkingMode,
-	useMetadataProgressUpdate,
-} from "~/lib/state/media";
+import { useMetadataProgressUpdate } from "~/lib/state/media";
 import type { MediaFormProps } from "../utils/form-types";
 
 export const ShowForm = (props: MediaFormProps) => {
@@ -57,33 +54,30 @@ export const ShowForm = (props: MediaFormProps) => {
 						})) || []
 				}
 			/>
-			<Paper p="xs" withBorder>
-				<SegmentedControl
-					size="xs"
-					fullWidth
-					data={[
-						{ label: "All", value: UpdateProgressShowMarkingMode.All },
-						{ label: "Season", value: UpdateProgressShowMarkingMode.Season },
-					]}
-					value={
-						metadataToUpdate.showMarkingMode ||
-						UpdateProgressShowMarkingMode.All
-					}
-					onChange={(value) => {
-						updateMetadataToUpdate(
-							produce(metadataToUpdate, (draft) => {
-								draft.showMarkingMode = value as UpdateProgressShowMarkingMode;
-							}),
-						);
-					}}
-				/>
-				<Text size="xs" c="dimmed" mt="xs">
-					{metadataToUpdate.showMarkingMode ===
-					UpdateProgressShowMarkingMode.Season
-						? "Mark all unseen episodes in this season before this"
-						: "Mark all unseen episodes before this"}
-				</Text>
-			</Paper>
+			<Checkbox
+				size="xs"
+				label="Mark all unseen episodes before this"
+				checked={metadataToUpdate.showAllEpisodesBefore || false}
+				onChange={(e) => {
+					updateMetadataToUpdate(
+						produce(metadataToUpdate, (draft) => {
+							draft.showAllEpisodesBefore = e.target.checked;
+						}),
+					);
+				}}
+			/>
+			<Checkbox
+				size="xs"
+				label="Mark all unseen episodes in this season before this"
+				checked={metadataToUpdate.showSeasonEpisodesBefore || false}
+				onChange={(e) => {
+					updateMetadataToUpdate(
+						produce(metadataToUpdate, (draft) => {
+							draft.showSeasonEpisodesBefore = e.target.checked;
+						}),
+					);
+				}}
+			/>
 		</>
 	);
 };

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/media-types/show-form.tsx
@@ -49,8 +49,8 @@ export const ShowForm = (props: MediaFormProps) => {
 					props.metadataDetails.showSpecifics?.seasons
 						.find((s) => s.seasonNumber === metadataToUpdate.showSeasonNumber)
 						?.episodes.map((e) => ({
-							label: `${e.episodeNumber}. ${e.name.toString()}`,
 							value: e.episodeNumber.toString(),
+							label: `${e.episodeNumber}. ${e.name.toString()}`,
 						})) || []
 				}
 			/>

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -207,8 +207,7 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext) => {
 const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Show &&
-		(context.metadataToUpdate.showAllEpisodesBefore ||
-			context.metadataToUpdate.showSeasonEpisodesBefore) &&
+		context.metadataToUpdate.showAllEpisodesBefore &&
 		context.metadataToUpdate.showSeasonNumber &&
 		context.metadataToUpdate.showEpisodeNumber
 	) {
@@ -218,39 +217,31 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 				s.episodes.map((e) => ({ seasonNumber: s.seasonNumber, ...e })),
 			) || [];
 
-		const useSeasonMode = context.metadataToUpdate.showSeasonEpisodesBefore;
-		const episodesToConsider = useSeasonMode
-			? allEpisodesInShow.filter(
-					(e) => e.seasonNumber === context.metadataToUpdate.showSeasonNumber,
-				)
-			: allEpisodesInShow;
-
-		const selectedEpisodeIndex = episodesToConsider.findIndex(
+		const selectedEpisodeIndex = allEpisodesInShow.findIndex(
 			(e) =>
 				e.seasonNumber === context.metadataToUpdate.showSeasonNumber &&
 				e.episodeNumber === context.metadataToUpdate.showEpisodeNumber,
 		);
 
-		const selectedEpisode = episodesToConsider[selectedEpisodeIndex];
-		const firstEpisodeOfShow = episodesToConsider[0];
+		const selectedEpisode = allEpisodesInShow[selectedEpisodeIndex];
+		const firstEpisodeOfShow = allEpisodesInShow[0];
 		const lastSeenEpisode = latestHistoryItem?.showExtraInformation || {
 			episode: firstEpisodeOfShow?.episodeNumber,
 			season: firstEpisodeOfShow?.seasonNumber,
 		};
 
-		const lastSeenEpisodeIndex = episodesToConsider.findIndex(
+		const lastSeenEpisodeIndex = allEpisodesInShow.findIndex(
 			(e) =>
 				e.seasonNumber === lastSeenEpisode.season &&
 				e.episodeNumber === lastSeenEpisode.episode,
 		);
 
-		const firstEpisodeIndexToMark = useSeasonMode
-			? 0
-			: lastSeenEpisodeIndex + (latestHistoryItem ? 1 : 0);
+		const firstEpisodeIndexToMark =
+			lastSeenEpisodeIndex + (latestHistoryItem ? 1 : 0);
 
 		if (selectedEpisodeIndex > firstEpisodeIndexToMark) {
 			for (let i = firstEpisodeIndexToMark; i < selectedEpisodeIndex; i++) {
-				const currentEpisode = episodesToConsider[i];
+				const currentEpisode = allEpisodesInShow[i];
 				if (
 					currentEpisode.seasonNumber === 0 &&
 					selectedEpisode.seasonNumber !== 0

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -6,7 +6,7 @@ import {
 import { isFiniteNumber } from "@ryot/ts-utils";
 import { match } from "ts-pattern";
 import { WatchTimes } from "~/components/routes/dashboard/types";
-import { ShowMarkingMode } from "~/lib/state/media";
+import { UpdateProgressShowMarkingMode } from "~/lib/state/media";
 import type { BulkUpdateContext } from "./form-types";
 
 export const createCustomDatesCompletedChange = (params: {
@@ -219,7 +219,8 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 			) || [];
 
 		const episodesToConsider =
-			context.metadataToUpdate.showMarkingMode === ShowMarkingMode.Season
+			context.metadataToUpdate.showMarkingMode ===
+			UpdateProgressShowMarkingMode.Season
 				? allEpisodesInShow.filter(
 						(e) => e.seasonNumber === context.metadataToUpdate.showSeasonNumber,
 					)
@@ -245,7 +246,8 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 		);
 
 		const firstEpisodeIndexToMark =
-			context.metadataToUpdate.showMarkingMode === ShowMarkingMode.Season
+			context.metadataToUpdate.showMarkingMode ===
+			UpdateProgressShowMarkingMode.Season
 				? 0
 				: lastSeenEpisodeIndex + (latestHistoryItem ? 1 : 0);
 

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -6,7 +6,12 @@ import {
 import { isFiniteNumber } from "@ryot/ts-utils";
 import { match } from "ts-pattern";
 import { WatchTimes } from "~/components/routes/dashboard/types";
+import type { MetadataDetails } from "~/components/routes/media-item/types";
 import type { BulkUpdateContext } from "./form-types";
+
+type EpisodeWithSeason = NonNullable<
+	MetadataDetails["showSpecifics"]
+>["seasons"][number]["episodes"][number] & { seasonNumber: number };
 
 export const createCustomDatesCompletedChange = (params: {
 	startDateFormatted: string | null;
@@ -212,52 +217,56 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 		context.metadataToUpdate.showSeasonNumber &&
 		context.metadataToUpdate.showEpisodeNumber
 	) {
-		const latestHistoryItem = context.history[0];
 		const allEpisodesInShow =
 			context.metadataDetails.showSpecifics?.seasons.flatMap((s) =>
 				s.episodes.map((e) => ({ seasonNumber: s.seasonNumber, ...e })),
 			) || [];
 
-		const selectedEpisodeIndex = allEpisodesInShow.findIndex(
+		const selectedEpisode = allEpisodesInShow.find(
 			(e) =>
 				e.seasonNumber === context.metadataToUpdate.showSeasonNumber &&
 				e.episodeNumber === context.metadataToUpdate.showEpisodeNumber,
 		);
 
-		const selectedEpisode = allEpisodesInShow[selectedEpisodeIndex];
-		const firstEpisodeOfShow = allEpisodesInShow[0];
-		const lastSeenEpisode = latestHistoryItem?.showExtraInformation || {
-			episode: firstEpisodeOfShow?.episodeNumber,
-			season: firstEpisodeOfShow?.seasonNumber,
+		if (!selectedEpisode) return;
+
+		const seenEpisodes = new Set<string>();
+		for (const historyItem of context.history) {
+			if (historyItem.showExtraInformation) {
+				const season = historyItem.showExtraInformation.season;
+				const episode = historyItem.showExtraInformation.episode;
+				seenEpisodes.add(`S${season}E${episode}`);
+			}
+		}
+
+		const episodeComesAfterOrIs = (
+			episodeA: EpisodeWithSeason,
+			episodeB: EpisodeWithSeason,
+		) => {
+			if (episodeA.seasonNumber > episodeB.seasonNumber) return true;
+			if (episodeA.seasonNumber === episodeB.seasonNumber) {
+				return episodeA.episodeNumber >= episodeB.episodeNumber;
+			}
+			return false;
 		};
 
-		const lastSeenEpisodeIndex = allEpisodesInShow.findIndex(
-			(e) =>
-				e.seasonNumber === lastSeenEpisode.season &&
-				e.episodeNumber === lastSeenEpisode.episode,
-		);
+		const episodesToConsider = allEpisodesInShow.filter((episode) => {
+			if (episodeComesAfterOrIs(episode, selectedEpisode)) return false;
 
-		const firstEpisodeIndexToMark =
-			lastSeenEpisodeIndex + (latestHistoryItem ? 1 : 0);
+			if (context.metadataToUpdate.showSeasonEpisodesBefore) {
+				if (episode.seasonNumber !== selectedEpisode.seasonNumber) return false;
+			}
 
-		if (selectedEpisodeIndex > firstEpisodeIndexToMark) {
-			for (let i = firstEpisodeIndexToMark; i < selectedEpisodeIndex; i++) {
-				const currentEpisode = allEpisodesInShow[i];
-				if (
-					currentEpisode.seasonNumber === 0 &&
-					selectedEpisode.seasonNumber !== 0
-				) {
-					continue;
-				}
+			if (episode.seasonNumber === 0 && selectedEpisode.seasonNumber !== 0) {
+				return false;
+			}
 
-				if (
-					context.metadataToUpdate.showSeasonEpisodesBefore &&
-					currentEpisode.seasonNumber !==
-						context.metadataToUpdate.showSeasonNumber
-				) {
-					continue;
-				}
+			return true;
+		});
 
+		for (const episode of episodesToConsider) {
+			const episodeKey = `S${episode.seasonNumber}E${episode.episodeNumber}`;
+			if (!seenEpisodes.has(episodeKey)) {
 				context.updates.push({
 					metadataId: context.metadataToUpdate.metadataId,
 					change: createUpdateChange({
@@ -267,8 +276,8 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 						finishDateFormatted: context.finishDateFormatted,
 						currentDateFormatted: context.currentDateFormatted,
 						fields: {
-							showSeasonNumber: currentEpisode.seasonNumber,
-							showEpisodeNumber: currentEpisode.episodeNumber,
+							showSeasonNumber: episode.seasonNumber,
+							showEpisodeNumber: episode.episodeNumber,
 						},
 					}),
 				});

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -6,7 +6,6 @@ import {
 import { isFiniteNumber } from "@ryot/ts-utils";
 import { match } from "ts-pattern";
 import { WatchTimes } from "~/components/routes/dashboard/types";
-import { UpdateProgressShowMarkingMode } from "~/lib/state/media";
 import type { BulkUpdateContext } from "./form-types";
 
 export const createCustomDatesCompletedChange = (params: {
@@ -208,7 +207,8 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext) => {
 const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Show &&
-		context.metadataToUpdate.showMarkingMode &&
+		(context.metadataToUpdate.showAllEpisodesBefore ||
+			context.metadataToUpdate.showSeasonEpisodesBefore) &&
 		context.metadataToUpdate.showSeasonNumber &&
 		context.metadataToUpdate.showEpisodeNumber
 	) {
@@ -218,13 +218,12 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 				s.episodes.map((e) => ({ seasonNumber: s.seasonNumber, ...e })),
 			) || [];
 
-		const episodesToConsider =
-			context.metadataToUpdate.showMarkingMode ===
-			UpdateProgressShowMarkingMode.Season
-				? allEpisodesInShow.filter(
-						(e) => e.seasonNumber === context.metadataToUpdate.showSeasonNumber,
-					)
-				: allEpisodesInShow;
+		const useSeasonMode = context.metadataToUpdate.showSeasonEpisodesBefore;
+		const episodesToConsider = useSeasonMode
+			? allEpisodesInShow.filter(
+					(e) => e.seasonNumber === context.metadataToUpdate.showSeasonNumber,
+				)
+			: allEpisodesInShow;
 
 		const selectedEpisodeIndex = episodesToConsider.findIndex(
 			(e) =>
@@ -245,11 +244,9 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 				e.episodeNumber === lastSeenEpisode.episode,
 		);
 
-		const firstEpisodeIndexToMark =
-			context.metadataToUpdate.showMarkingMode ===
-			UpdateProgressShowMarkingMode.Season
-				? 0
-				: lastSeenEpisodeIndex + (latestHistoryItem ? 1 : 0);
+		const firstEpisodeIndexToMark = useSeasonMode
+			? 0
+			: lastSeenEpisodeIndex + (latestHistoryItem ? 1 : 0);
 
 		if (selectedEpisodeIndex > firstEpisodeIndexToMark) {
 			for (let i = firstEpisodeIndexToMark; i < selectedEpisodeIndex; i++) {

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/utils/bulk-update-handlers.ts
@@ -207,7 +207,8 @@ const handleMangaBulkUpdates = (context: BulkUpdateContext) => {
 const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 	if (
 		context.metadataDetails.lot === MediaLot.Show &&
-		context.metadataToUpdate.showAllEpisodesBefore &&
+		(context.metadataToUpdate.showAllEpisodesBefore ||
+			context.metadataToUpdate.showSeasonEpisodesBefore) &&
 		context.metadataToUpdate.showSeasonNumber &&
 		context.metadataToUpdate.showEpisodeNumber
 	) {
@@ -245,6 +246,14 @@ const handleShowBulkUpdates = (context: BulkUpdateContext) => {
 				if (
 					currentEpisode.seasonNumber === 0 &&
 					selectedEpisode.seasonNumber !== 0
+				) {
+					continue;
+				}
+
+				if (
+					context.metadataToUpdate.showSeasonEpisodesBefore &&
+					currentEpisode.seasonNumber !==
+						context.metadataToUpdate.showSeasonNumber
 				) {
 					continue;
 				}

--- a/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
+++ b/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
@@ -1,9 +1,6 @@
 import { Box, Button } from "@mantine/core";
 import { sum } from "@ryot/ts-utils";
-import {
-	UpdateProgressShowMarkingMode,
-	useMetadataProgressUpdate,
-} from "~/lib/state/media";
+import { useMetadataProgressUpdate } from "~/lib/state/media";
 import type { Season, UserMetadataDetails } from "../types";
 import { DisplaySeasonOrEpisodeDetails } from "./season-episode-details";
 
@@ -43,7 +40,7 @@ export const DisplayShowSeason = (props: {
 						variant={isSeen ? "default" : "outline"}
 						onClick={() => {
 							initializeMetadataToUpdate({
-								showMarkingMode: UpdateProgressShowMarkingMode.Season,
+								showAllEpisodesBefore: true,
 								metadataId: props.metadataId,
 								showSeasonNumber: props.season.seasonNumber,
 								showEpisodeNumber: props.season.episodes.at(-1)?.episodeNumber,

--- a/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
+++ b/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
@@ -1,6 +1,9 @@
 import { Box, Button } from "@mantine/core";
 import { sum } from "@ryot/ts-utils";
-import { ShowMarkingMode, useMetadataProgressUpdate } from "~/lib/state/media";
+import {
+	UpdateProgressShowMarkingMode,
+	useMetadataProgressUpdate,
+} from "~/lib/state/media";
 import type { Season, UserMetadataDetails } from "../types";
 import { DisplaySeasonOrEpisodeDetails } from "./season-episode-details";
 
@@ -40,7 +43,7 @@ export const DisplayShowSeason = (props: {
 						variant={isSeen ? "default" : "outline"}
 						onClick={() => {
 							initializeMetadataToUpdate({
-								showMarkingMode: ShowMarkingMode.Season,
+								showMarkingMode: UpdateProgressShowMarkingMode.Season,
 								metadataId: props.metadataId,
 								showSeasonNumber: props.season.seasonNumber,
 								showEpisodeNumber: props.season.episodes.at(-1)?.episodeNumber,

--- a/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
+++ b/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from "@mantine/core";
 import { sum } from "@ryot/ts-utils";
-import { useMetadataProgressUpdate } from "~/lib/state/media";
+import { ShowMarkingMode, useMetadataProgressUpdate } from "~/lib/state/media";
 import type { Season, UserMetadataDetails } from "../types";
 import { DisplaySeasonOrEpisodeDetails } from "./season-episode-details";
 
@@ -40,7 +40,7 @@ export const DisplayShowSeason = (props: {
 						variant={isSeen ? "default" : "outline"}
 						onClick={() => {
 							initializeMetadataToUpdate({
-								showAllEpisodesBefore: true,
+								showMarkingMode: ShowMarkingMode.Season,
 								metadataId: props.metadataId,
 								showSeasonNumber: props.season.seasonNumber,
 								showEpisodeNumber: props.season.episodes.at(-1)?.episodeNumber,

--- a/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
+++ b/apps/frontend/app/components/routes/media-item/displays/show-season.tsx
@@ -40,7 +40,6 @@ export const DisplayShowSeason = (props: {
 						variant={isSeen ? "default" : "outline"}
 						onClick={() => {
 							initializeMetadataToUpdate({
-								showAllEpisodesBefore: true,
 								metadataId: props.metadataId,
 								showSeasonNumber: props.season.seasonNumber,
 								showEpisodeNumber: props.season.episodes.at(-1)?.episodeNumber,

--- a/apps/frontend/app/lib/state/media.ts
+++ b/apps/frontend/app/lib/state/media.ts
@@ -17,6 +17,11 @@ import {
 	queryClient,
 } from "~/lib/shared/query-factory";
 
+export enum ShowMarkingMode {
+	All = "all",
+	Season = "season",
+}
+
 export type UpdateProgressData = {
 	metadataId: string;
 	showSeasonNumber?: number;
@@ -26,7 +31,7 @@ export type UpdateProgressData = {
 	mangaChapterNumber?: string;
 	podcastEpisodeNumber?: number;
 	providersConsumedOn?: string[];
-	showAllEpisodesBefore?: boolean;
+	showMarkingMode?: ShowMarkingMode;
 	animeAllEpisodesBefore?: boolean;
 	podcastAllEpisodesBefore?: boolean;
 	mangaAllChaptersOrVolumesBefore?: boolean;

--- a/apps/frontend/app/lib/state/media.ts
+++ b/apps/frontend/app/lib/state/media.ts
@@ -17,7 +17,7 @@ import {
 	queryClient,
 } from "~/lib/shared/query-factory";
 
-export enum ShowMarkingMode {
+export enum UpdateProgressShowMarkingMode {
 	All = "all",
 	Season = "season",
 }
@@ -31,10 +31,10 @@ export type UpdateProgressData = {
 	mangaChapterNumber?: string;
 	podcastEpisodeNumber?: number;
 	providersConsumedOn?: string[];
-	showMarkingMode?: ShowMarkingMode;
 	animeAllEpisodesBefore?: boolean;
 	podcastAllEpisodesBefore?: boolean;
 	mangaAllChaptersOrVolumesBefore?: boolean;
+	showMarkingMode?: UpdateProgressShowMarkingMode;
 };
 
 const metadataProgressUpdateAtom = atom<UpdateProgressData | null>(null);

--- a/apps/frontend/app/lib/state/media.ts
+++ b/apps/frontend/app/lib/state/media.ts
@@ -17,11 +17,6 @@ import {
 	queryClient,
 } from "~/lib/shared/query-factory";
 
-export enum UpdateProgressShowMarkingMode {
-	All = "all",
-	Season = "season",
-}
-
 export type UpdateProgressData = {
 	metadataId: string;
 	showSeasonNumber?: number;
@@ -31,10 +26,11 @@ export type UpdateProgressData = {
 	mangaChapterNumber?: string;
 	podcastEpisodeNumber?: number;
 	providersConsumedOn?: string[];
+	showAllEpisodesBefore?: boolean;
 	animeAllEpisodesBefore?: boolean;
 	podcastAllEpisodesBefore?: boolean;
+	showSeasonEpisodesBefore?: boolean;
 	mangaAllChaptersOrVolumesBefore?: boolean;
-	showMarkingMode?: UpdateProgressShowMarkingMode;
 };
 
 const metadataProgressUpdateAtom = atom<UpdateProgressData | null>(null);


### PR DESCRIPTION
Fixes #1508.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new option to mark all unseen episodes in the current season before the selected episode.
  * Updated episode selection dropdown and checkboxes for clearer progress marking controls.

* **Enhancements**
  * Enhanced bulk update logic to support marking episodes either across the entire show or limited to the current season.
  * Improved state management for episode marking checkboxes to ensure consistent user interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->