### PR TITLE
Add link to werstreamt.es importer

### DIFF
--- a/apps/docs/src/importing/community.md
+++ b/apps/docs/src/importing/community.md
@@ -3,5 +3,6 @@
 These are community maintained import mechanisms. Ryot does not officially support them.
 
 - [TV Time](https://github.com/SirMartin/TvTimeToRyot) by [@SirMartin](https://github.com/SirMartin)
+- [WerStreamt.es](https://github.com/DoPri/werstreamtes-to-ryot) by [@DoPri](https://github.com/DoPri)
 
 Want to add your own importer? Open a [pull request](../contributing.md)!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community importer entry for WerStreamt.es.
  * Updated the Community section to include WerStreamt.es alongside TV Time.
  * No functional or code changes included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->