### PR TITLE
Add media collection strategy filter and enhance UI interactions

### DIFF
--- a/apps/frontend/app/components/common/filters.tsx
+++ b/apps/frontend/app/components/common/filters.tsx
@@ -4,12 +4,12 @@ import {
 	Button,
 	Group,
 	Modal,
-	rem,
 	Select,
 	Stack,
 	Text,
 	TextInput,
 	Title,
+	rem,
 } from "@mantine/core";
 import {
 	randomId,
@@ -22,6 +22,7 @@ import {
 	MediaCollectionPresenceFilter,
 	MediaCollectionStrategyFilter,
 } from "@ryot/generated/graphql/backend/graphql";
+import { changeCase } from "@ryot/ts-utils";
 import {
 	IconFilterOff,
 	IconPlus,
@@ -34,7 +35,6 @@ import {
 	useCoreDetails,
 	useNonHiddenUserCollections,
 } from "~/lib/shared/hooks";
-import { convertEnumToSelectData } from "~/lib/shared/ui-utils";
 import type { OnboardingTourStepTargets } from "~/lib/state/onboarding-tour";
 import { ProRequiredAlert } from ".";
 
@@ -137,20 +137,25 @@ export const CollectionsFilter = (props: {
 									{f.data.strategy}
 								</Button>
 							) : null}
-							<Select
+							<Button
 								size="xs"
-								value={f.data.presence}
-								allowDeselect={false}
-								data={convertEnumToSelectData(MediaCollectionPresenceFilter)}
-								onChange={(v) =>
+								w={rem(200)}
+								variant="default"
+								onClick={() => {
 									filtersHandlers.setItem(
 										idx,
 										produce(f, (d) => {
-											d.data.presence = v as MediaCollectionPresenceFilter;
+											d.data.presence =
+												d.data.presence ===
+												MediaCollectionPresenceFilter.PresentIn
+													? MediaCollectionPresenceFilter.NotPresentIn
+													: MediaCollectionPresenceFilter.PresentIn;
 										}),
-									)
-								}
-							/>
+									);
+								}}
+							>
+								{changeCase(f.data.presence)}
+							</Button>
 							<Select
 								size="xs"
 								searchable

--- a/apps/frontend/app/components/common/filters.tsx
+++ b/apps/frontend/app/components/common/filters.tsx
@@ -4,6 +4,7 @@ import {
 	Button,
 	Group,
 	Modal,
+	rem,
 	Select,
 	Stack,
 	Text,
@@ -117,9 +118,24 @@ export const CollectionsFilter = (props: {
 					{filters.map((f, idx) => (
 						<Group key={f.id} justify="space-between" wrap="nowrap">
 							{idx !== 0 ? (
-								<Text size="xs" c="dimmed">
-									OR
-								</Text>
+								<Button
+									size="xs"
+									w={rem(90)}
+									variant="default"
+									onClick={() => {
+										filtersHandlers.setItem(
+											idx,
+											produce(f, (d) => {
+												d.data.strategy =
+													d.data.strategy === MediaCollectionStrategyFilter.And
+														? MediaCollectionStrategyFilter.Or
+														: MediaCollectionStrategyFilter.And;
+											}),
+										);
+									}}
+								>
+									{f.data.strategy}
+								</Button>
 							) : null}
 							<Select
 								size="xs"

--- a/apps/frontend/app/components/common/filters.tsx
+++ b/apps/frontend/app/components/common/filters.tsx
@@ -135,7 +135,7 @@ export const CollectionsFilter = (props: {
 										);
 									}}
 								>
-									{f.data.strategy}
+									{changeCase(f.data.strategy)}
 								</Button>
 							) : null}
 							<Button

--- a/apps/frontend/app/components/common/filters.tsx
+++ b/apps/frontend/app/components/common/filters.tsx
@@ -114,14 +114,15 @@ export const CollectionsFilter = (props: {
 				</Button>
 			</Group>
 			{filters.length > 0 ? (
-				<Stack gap="xs" px={{ md: "xs" }} ref={parent}>
+				<Stack gap="xs" px={{ md: 4 }} ref={parent}>
 					{filters.map((f, idx) => (
-						<Group key={f.id} justify="space-between" wrap="nowrap">
+						<Group key={f.id} gap="xs" justify="space-between" wrap="nowrap">
 							{idx !== 0 ? (
 								<Button
-									size="xs"
-									w={rem(90)}
+									size="compact-md"
+									w={rem(70)}
 									variant="default"
+									fz={{ base: 10, md: 12 }}
 									onClick={() => {
 										filtersHandlers.setItem(
 											idx,
@@ -138,9 +139,10 @@ export const CollectionsFilter = (props: {
 								</Button>
 							) : null}
 							<Button
-								size="xs"
-								w={rem(200)}
+								size="compact-md"
+								w={rem(170)}
 								variant="default"
+								fz={{ base: 10, md: 12 }}
 								onClick={() => {
 									filtersHandlers.setItem(
 										idx,

--- a/crates/models/media/src/graphql_types.rs
+++ b/crates/models/media/src/graphql_types.rs
@@ -140,6 +140,13 @@ pub enum MediaGeneralFilter {
 }
 
 #[derive(Debug, Hash, Serialize, Deserialize, Enum, Clone, Copy, Eq, PartialEq, Default)]
+pub enum MediaCollectionStrategyFilter {
+    #[default]
+    Or,
+    And,
+}
+
+#[derive(Debug, Hash, Serialize, Deserialize, Enum, Clone, Copy, Eq, PartialEq, Default)]
 pub enum MediaCollectionPresenceFilter {
     #[default]
     PresentIn,
@@ -149,6 +156,7 @@ pub enum MediaCollectionPresenceFilter {
 #[derive(Debug, Hash, PartialEq, Eq, Serialize, Deserialize, InputObject, Clone, Default)]
 pub struct MediaCollectionFilter {
     pub collection_id: String,
+    pub strategy: MediaCollectionStrategyFilter,
     pub presence: MediaCollectionPresenceFilter,
 }
 

--- a/libs/generated/src/graphql/backend/graphql.ts
+++ b/libs/generated/src/graphql/backend/graphql.ts
@@ -1155,11 +1155,17 @@ export type MediaCollectionContentsResults = {
 export type MediaCollectionFilter = {
   collectionId: Scalars['String']['input'];
   presence: MediaCollectionPresenceFilter;
+  strategy: MediaCollectionStrategyFilter;
 };
 
 export enum MediaCollectionPresenceFilter {
   NotPresentIn = 'NOT_PRESENT_IN',
   PresentIn = 'PRESENT_IN'
+}
+
+export enum MediaCollectionStrategyFilter {
+  And = 'AND',
+  Or = 'OR'
 }
 
 export type MediaFilter = {

--- a/libs/generated/src/graphql/backend/types.generated.ts
+++ b/libs/generated/src/graphql/backend/types.generated.ts
@@ -1188,11 +1188,17 @@ export type MediaCollectionContentsResults = {
 export type MediaCollectionFilter = {
   collectionId: Scalars['String']['input'];
   presence: MediaCollectionPresenceFilter;
+  strategy: MediaCollectionStrategyFilter;
 };
 
 export enum MediaCollectionPresenceFilter {
   NotPresentIn = 'NOT_PRESENT_IN',
   PresentIn = 'PRESENT_IN'
+}
+
+export enum MediaCollectionStrategyFilter {
+  And = 'AND',
+  Or = 'OR'
 }
 
 export type MediaFilter = {


### PR DESCRIPTION
Introduce a `MediaCollectionStrategyFilter` to allow users to specify the application of multiple collection filters. Update the `CollectionsFilter` component to include a toggle button for the filter strategy, improving user experience by simplifying interactions. Enhance the styling and responsiveness of filter buttons for a cleaner interface.

Fixes #1529.
Fixes #1536.