### PR TITLE
Allow creating custom metadata group and person

### DIFF
--- a/apps/backend/src/common.rs
+++ b/apps/backend/src/common.rs
@@ -15,7 +15,6 @@ use bon::builder;
 use collection_resolver::{CollectionMutationResolver, CollectionQueryResolver};
 use collection_service::CollectionService;
 use config_definition::AppConfig;
-use custom_resolver::CustomMutationResolver;
 use exporter_resolver::{ExporterMutationResolver, ExporterQueryResolver};
 use exporter_service::ExporterService;
 use file_storage_resolver::{FileStorageMutationResolver, FileStorageQueryResolver};
@@ -226,7 +225,6 @@ pub struct QueryRoot(
 
 #[derive(MergedObject, Default)]
 pub struct MutationRoot(
-    CustomMutationResolver,
     FitnessMutationResolver,
     ExporterMutationResolver,
     ImporterMutationResolver,

--- a/apps/backend/src/common.rs
+++ b/apps/backend/src/common.rs
@@ -15,6 +15,7 @@ use bon::builder;
 use collection_resolver::{CollectionMutationResolver, CollectionQueryResolver};
 use collection_service::CollectionService;
 use config_definition::AppConfig;
+use custom_resolver::CustomMutationResolver;
 use exporter_resolver::{ExporterMutationResolver, ExporterQueryResolver};
 use exporter_service::ExporterService;
 use file_storage_resolver::{FileStorageMutationResolver, FileStorageQueryResolver};
@@ -206,37 +207,38 @@ impl KeyExtractor for RateLimitExtractor {
 
 #[derive(MergedObject, Default)]
 pub struct QueryRoot(
-    MiscellaneousMetadataQueryResolver,
-    MiscellaneousSearchQueryResolver,
-    MiscellaneousSocialQueryResolver,
-    MiscellaneousGroupingQueryResolver,
-    MiscellaneousTrackingQueryResolver,
-    MiscellaneousSystemQueryResolver,
-    UserAuthenticationQueryResolver,
-    UserManagementQueryResolver,
-    UserServicesQueryResolver,
+    FitnessQueryResolver,
     ImporterQueryResolver,
     ExporterQueryResolver,
-    FitnessQueryResolver,
-    FileStorageQueryResolver,
     StatisticsQueryResolver,
     CollectionQueryResolver,
+    FileStorageQueryResolver,
+    UserServicesQueryResolver,
+    UserManagementQueryResolver,
+    UserAuthenticationQueryResolver,
+    MiscellaneousSearchQueryResolver,
+    MiscellaneousSocialQueryResolver,
+    MiscellaneousSystemQueryResolver,
+    MiscellaneousGroupingQueryResolver,
+    MiscellaneousTrackingQueryResolver,
+    MiscellaneousMetadataQueryResolver,
 );
 
 #[derive(MergedObject, Default)]
 pub struct MutationRoot(
-    MiscellaneousMetadataMutationResolver,
-    MiscellaneousSocialMutationResolver,
-    MiscellaneousTrackingMutationResolver,
-    MiscellaneousSystemMutationResolver,
-    UserAuthenticationMutationResolver,
-    UserManagementMutationResolver,
-    UserServicesMutationResolver,
-    ImporterMutationResolver,
-    ExporterMutationResolver,
+    CustomMutationResolver,
     FitnessMutationResolver,
-    FileStorageMutationResolver,
+    ExporterMutationResolver,
+    ImporterMutationResolver,
     CollectionMutationResolver,
+    FileStorageMutationResolver,
+    UserServicesMutationResolver,
+    UserManagementMutationResolver,
+    UserAuthenticationMutationResolver,
+    MiscellaneousSocialMutationResolver,
+    MiscellaneousSystemMutationResolver,
+    MiscellaneousTrackingMutationResolver,
+    MiscellaneousMetadataMutationResolver,
 );
 
 pub type GraphqlSchema = Schema<QueryRoot, MutationRoot, EmptySubscription>;

--- a/crates/migrations/sql/src/lib.rs
+++ b/crates/migrations/sql/src/lib.rs
@@ -32,6 +32,7 @@ mod m20250826_changes_for_issue_1529;
 mod m20250827_create_enriched_user_to_entity_views;
 mod m20250907_changes_for_issue_1533;
 mod m20250908_changes_for_issue_1551;
+mod m20250914_changes_for_issue_1561;
 
 pub use m20230404_create_user::User as AliasedUser;
 pub use m20230410_create_metadata::Metadata as AliasedMetadata;
@@ -81,6 +82,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250827_create_enriched_user_to_entity_views::Migration),
             Box::new(m20250907_changes_for_issue_1533::Migration),
             Box::new(m20250908_changes_for_issue_1551::Migration),
+            Box::new(m20250914_changes_for_issue_1561::Migration),
         ]
     }
 }

--- a/crates/migrations/sql/src/m20230411_create_metadata_group.rs
+++ b/crates/migrations/sql/src/m20230411_create_metadata_group.rs
@@ -1,10 +1,13 @@
 use migrations_utils::create_trigram_index_if_required;
 use sea_orm_migration::prelude::*;
 
+use super::m20230404_create_user::User;
+
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
 pub static METADATA_GROUP_TITLE_TRIGRAM_INDEX: &str = "metadata_group_title_trigram_idx";
+pub static METADATA_GROUP_TO_USER_FOREIGN_KEY: &str = "metadata_group_to_user_foreign_key";
 pub static METADATA_GROUP_DESCRIPTION_TRIGRAM_INDEX: &str =
     "metadata_group_description_trigram_idx";
 
@@ -21,6 +24,7 @@ pub enum MetadataGroup {
     Source,
     IsPartial,
     SourceUrl,
+    CreatedByUserId,
 }
 
 #[async_trait::async_trait]
@@ -53,6 +57,15 @@ impl MigrationTrait for Migration {
                         ColumnDef::new(MetadataGroup::Assets)
                             .json_binary()
                             .not_null(),
+                    )
+                    .col(ColumnDef::new(MetadataGroup::CreatedByUserId).text())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name(METADATA_GROUP_TO_USER_FOREIGN_KEY)
+                            .from(MetadataGroup::Table, MetadataGroup::CreatedByUserId)
+                            .to(User::Table, User::Id)
+                            .on_delete(ForeignKeyAction::SetNull)
+                            .on_update(ForeignKeyAction::Cascade),
                     )
                     .to_owned(),
             )

--- a/crates/migrations/sql/src/m20230413_create_person.rs
+++ b/crates/migrations/sql/src/m20230413_create_person.rs
@@ -1,12 +1,16 @@
 use migrations_utils::create_trigram_index_if_required;
 use sea_orm_migration::prelude::*;
 
-use super::{m20230410_create_metadata::Metadata, m20230411_create_metadata_group::MetadataGroup};
+use super::{
+    m20230404_create_user::User, m20230410_create_metadata::Metadata,
+    m20230411_create_metadata_group::MetadataGroup,
+};
 
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
 pub static METADATA_TO_PERSON_PRIMARY_KEY: &str = "pk-media-item_person";
+pub static PERSON_TO_USER_FOREIGN_KEY: &str = "person_to_user_foreign_key";
 pub static PERSON_IDENTIFIER_UNIQUE_KEY: &str = "person-identifier-source__unique_index";
 pub static PERSON_ASSOCIATED_METADATA_COUNT_GENERATED_SQL: &str = r#"GENERATED ALWAYS AS (COALESCE(JSONB_ARRAY_LENGTH("state_changes"->'metadata_associated'), 0)) STORED"#;
 pub static PERSON_ASSOCIATED_METADATA_GROUPS_COUNT_GENERATED_SQL: &str = r#"GENERATED ALWAYS AS (COALESCE(JSONB_ARRAY_LENGTH("state_changes"->'metadata_groups_associated'), 0)) STORED"#;
@@ -34,6 +38,7 @@ pub enum Person {
     StateChanges,
     LastUpdatedOn,
     AlternateNames,
+    CreatedByUserId,
     SourceSpecifics,
     AssociatedEntityCount,
     AssociatedMetadataCount,
@@ -113,6 +118,15 @@ impl MigrationTrait for Migration {
                             .extra(PERSON_ASSOCIATED_ENTITY_COUNT_GENERATED_SQL),
                     )
                     .col(ColumnDef::new(Person::Assets).json_binary().not_null())
+                    .col(ColumnDef::new(Person::CreatedByUserId).text())
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name(PERSON_TO_USER_FOREIGN_KEY)
+                            .from(Person::Table, Person::CreatedByUserId)
+                            .to(User::Table, User::Id)
+                            .on_delete(ForeignKeyAction::SetNull)
+                            .on_update(ForeignKeyAction::Cascade),
+                    )
                     .to_owned(),
             )
             .await?;

--- a/crates/migrations/sql/src/m20250914_changes_for_issue_1561.rs
+++ b/crates/migrations/sql/src/m20250914_changes_for_issue_1561.rs
@@ -1,0 +1,49 @@
+use sea_orm_migration::prelude::*;
+
+use super::{
+    m20230411_create_metadata_group::METADATA_GROUP_TO_USER_FOREIGN_KEY,
+    m20230413_create_person::PERSON_TO_USER_FOREIGN_KEY,
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        if !manager.has_column("person", "created_by_user_id").await? {
+            db.execute_unprepared(&format!(
+                r#"
+ALTER TABLE "person" ADD COLUMN "created_by_user_id" TEXT;
+
+ALTER TABLE "person" ADD CONSTRAINT "{PERSON_TO_USER_FOREIGN_KEY}"
+FOREIGN KEY ("created_by_user_id") REFERENCES "user"("id") ON UPDATE CASCADE ON DELETE SET NULL;
+"#
+            ))
+            .await?;
+        }
+
+        if !manager
+            .has_column("metadata_group", "created_by_user_id")
+            .await?
+        {
+            db.execute_unprepared(&format!(
+                r#"
+ALTER TABLE "metadata_group" ADD COLUMN "created_by_user_id" TEXT;
+
+ALTER TABLE "metadata_group" ADD CONSTRAINT "{METADATA_GROUP_TO_USER_FOREIGN_KEY}"
+FOREIGN KEY ("created_by_user_id") REFERENCES "user"("id") ON UPDATE CASCADE ON DELETE SET NULL;
+"#
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/models/database/src/metadata_group.rs
+++ b/crates/models/database/src/metadata_group.rs
@@ -34,6 +34,8 @@ pub struct Model {
     pub is_partial: Option<bool>,
     pub source_url: Option<String>,
     pub description: Option<String>,
+    #[boilermates(not_in("MetadataGroupWithoutId"))]
+    pub created_by_user_id: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -46,6 +48,14 @@ pub enum Relation {
     MetadataToMetadataGroup,
     #[sea_orm(has_many = "super::review::Entity")]
     Review,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::CreatedByUserId",
+        to = "super::user::Column::Id",
+        on_update = "Cascade",
+        on_delete = "SetNull"
+    )]
+    User,
     #[sea_orm(has_many = "super::user_to_entity::Entity")]
     UserToEntity,
 }
@@ -71,6 +81,12 @@ impl Related<super::metadata_to_metadata_group::Entity> for Entity {
 impl Related<super::review::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Review.def()
+    }
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
     }
 }
 

--- a/crates/models/database/src/person.rs
+++ b/crates/models/database/src/person.rs
@@ -35,6 +35,7 @@ pub struct Model {
     pub birth_date: Option<NaiveDate>,
     pub death_date: Option<NaiveDate>,
     pub associated_metadata_count: i32,
+    pub created_by_user_id: Option<String>,
     pub alternate_names: Option<Vec<String>>,
     pub associated_metadata_groups_count: i32,
     #[graphql(skip)]
@@ -55,6 +56,14 @@ pub enum Relation {
     Review,
     #[sea_orm(has_many = "super::user_to_entity::Entity")]
     UserToEntity,
+    #[sea_orm(
+        belongs_to = "super::user::Entity",
+        from = "Column::CreatedByUserId",
+        to = "super::user::Column::Id",
+        on_update = "Cascade",
+        on_delete = "SetNull"
+    )]
+    User,
 }
 
 impl Related<super::collection_to_entity::Entity> for Entity {
@@ -78,6 +87,12 @@ impl Related<super::metadata_to_person::Entity> for Entity {
 impl Related<super::review::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Review.def()
+    }
+}
+
+impl Related<super::user::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
     }
 }
 

--- a/crates/models/database/src/user.rs
+++ b/crates/models/database/src/user.rs
@@ -44,8 +44,12 @@ pub enum Relation {
     Integration,
     #[sea_orm(has_many = "super::metadata::Entity")]
     Metadata,
+    #[sea_orm(has_many = "super::metadata_group::Entity")]
+    MetadataGroup,
     #[sea_orm(has_many = "super::notification_platform::Entity")]
     NotificationPlatform,
+    #[sea_orm(has_many = "super::person::Entity")]
+    Person,
     #[sea_orm(has_many = "super::review::Entity")]
     Review,
     #[sea_orm(has_many = "super::seen::Entity")]

--- a/libs/generated/src/graphql/backend/graphql.ts
+++ b/libs/generated/src/graphql/backend/graphql.ts
@@ -1289,6 +1289,7 @@ export type MetadataExternalIdentifiers = {
 
 export type MetadataGroup = {
   assets: EntityAssets;
+  createdByUserId?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   identifier: Scalars['String']['output'];
@@ -1898,6 +1899,7 @@ export type Person = {
   associatedMetadataCount: Scalars['Int']['output'];
   associatedMetadataGroupsCount: Scalars['Int']['output'];
   birthDate?: Maybe<Scalars['NaiveDate']['output']>;
+  createdByUserId?: Maybe<Scalars['String']['output']>;
   createdOn: Scalars['DateTime']['output'];
   deathDate?: Maybe<Scalars['NaiveDate']['output']>;
   description?: Maybe<Scalars['String']['output']>;

--- a/libs/generated/src/graphql/backend/types.generated.ts
+++ b/libs/generated/src/graphql/backend/types.generated.ts
@@ -1334,6 +1334,7 @@ export type MetadataExternalIdentifiers = {
 export type MetadataGroup = {
   __typename?: 'MetadataGroup';
   assets: EntityAssets;
+  createdByUserId?: Maybe<Scalars['String']['output']>;
   description?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   identifier: Scalars['String']['output'];
@@ -1954,6 +1955,7 @@ export type Person = {
   associatedMetadataCount: Scalars['Int']['output'];
   associatedMetadataGroupsCount: Scalars['Int']['output'];
   birthDate?: Maybe<Scalars['NaiveDate']['output']>;
+  createdByUserId?: Maybe<Scalars['String']['output']>;
   createdOn: Scalars['DateTime']['output'];
   deathDate?: Maybe<Scalars['NaiveDate']['output']>;
   description?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
Fixes #1561.

Introduce foreign key relationships for user ownership in the Person and MetadataGroup tables, enhancing data integrity. Reorganize query and mutation resolvers for better structure and clarity. Remove unused resolver to streamline the codebase.