### PR TITLE
Allow bulk adding exercises and workouts to collections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
   checking, running tests, etc.) should use `moon` commands.
 - You can read @apps/docs/src/contributing.md for an overview of the project architecture
   and some common commands.
+- When running bash commands (`git`, `sed` etc.), especially for the frontend projects, please remember to
+  quote the paths properly since they often contain special characters.
 - When making changes to the code, run the following commands generously to ensure that the
   changes you are making do not break anything:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
   moon run tests:typecheck
   ```
 
-- When running tests, compile the backend in release mode and implement the feature first,
+- When running tests, implement the feature first and compile the backend in release mode,
   then always ask the user's approval before executing tests to save iteration time.
 - After adding a GraphQL query or mutation to the backend, run `moon run
   generated:backend-graphql` so that the frontend can use the new query or mutation. Beforehand,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,5 +40,6 @@
   function arguments. Use `props.propertyName` syntax rather than destructuring
   `{ propertyName }` in the function signature.
 - When asked to create a git commit, read all the dirty changes in the repository and then
-  create logical commits, grouping related changes together. Commit messages should be
-  verbose and explain the reasoning behind the changes, not just what was changed.
+  create logical commits, grouping related changes together. Create multiple commits as
+  needed. Commit messages should be verbose and explain the reasoning behind the changes,
+  not just what was changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
   checking, running tests, etc.) should use `moon` commands.
 - You can read @apps/docs/src/contributing.md for an overview of the project architecture
   and some common commands.
-- When running bash commands (`git`, `sed` etc.), especially for the frontend projects, please remember to
-  quote the paths properly since they often contain special characters.
+- When running bash commands (`git`, `sed` etc.), especially for the frontend projects,
+  please remember to quote the paths properly since they often contain special characters.
 - When making changes to the code, run the following commands generously to ensure that the
   changes you are making do not break anything:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,15 +24,15 @@
   generated:backend-graphql` so that the frontend can use the new query or mutation. Beforehand,
   ensure the backend server is running in the background, and stop it after the generation completes.
 - Do not add code comments unless strictly necessary.
-- The migration files should be named `m<YYYYMMDD>_changes_for_issue_<number>`. Read other
-  migration files for examples.
-- We do not have down migrations since we always roll forward. It should just be an empty
-  block with `Ok(())`.
 - Since this is an open-source project, we have a slightly different approach to writing
   migrations. When adding a migration with a schema change, if the table you are working
   with already exists, then the same change should be applied to the migration where this
   table was first created. We need to do this so that new instances of Ryot can have the
   same table structure right off the bat.
+- The migration files should be named `m<YYYYMMDD>_changes_for_issue_<number>`. Read other
+  migration files for examples.
+- We do not have down migrations since we always roll forward. It should just be an empty
+  block with `Ok(())`.
 - We try to keep the code files below 500 lines. If a file is larger than that, consider
   splitting it into smaller files (using functions, components, etc.) to improve
   readability.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
   checking, running tests, etc.) should use `moon` commands.
 - You can read @apps/docs/src/contributing.md for an overview of the project architecture
   and some common commands.
-- When running bash commands (`git`, `sed` etc.), especially for the frontend projects,
-  please remember to quote the paths properly since they often contain special characters.
+- When running bash commands (`git`, `sed`), please remember to quote the paths using
+  single quotes since they often contain special characters.
 - When making changes to the code, run the following commands generously to ensure that the
   changes you are making do not break anything:
 

--- a/apps/docs/src/contributing.md
+++ b/apps/docs/src/contributing.md
@@ -13,7 +13,7 @@
   ```bash title=".env"
   DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres
   UNKEY_API_ID=dummy-api-id
-  APP_VERSION=v5.2.1
+  APP_VERSION=v9.2.2
   ```
 
 - Run the following commands in separate terminals:

--- a/apps/docs/src/contributing.md
+++ b/apps/docs/src/contributing.md
@@ -1,7 +1,7 @@
 # Contributing
 
 :::info
-CLAUDE.md is an excellent place to start reading on coding conventions followed in this project.
+`AGENTS.md` is an excellent place to start reading on coding conventions followed in this project.
 :::
 
 - Install [Rust](https://www.rust-lang.org), [Moon](https://moonrepo.dev) and

--- a/apps/frontend/app/components/common/BulkCollectionEditingAffix.tsx
+++ b/apps/frontend/app/components/common/BulkCollectionEditingAffix.tsx
@@ -1,0 +1,222 @@
+import {
+	ActionIcon,
+	Affix,
+	Button,
+	Group,
+	Modal,
+	Paper,
+	Stack,
+	Text,
+	rem,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { notifications } from "@mantine/notifications";
+import type {
+	EntityToCollectionInput,
+	Scalars,
+} from "@ryot/generated/graphql/backend/graphql";
+import { changeCase } from "@ryot/ts-utils";
+import { IconCancel } from "@tabler/icons-react";
+import { type FormEvent, useState } from "react";
+import {
+	useAddEntitiesToCollectionMutation,
+	useFormValidation,
+	useRemoveEntitiesFromCollectionMutation,
+	useUserCollections,
+} from "~/lib/shared/hooks";
+import { openConfirmationModal } from "~/lib/shared/ui-utils";
+import {
+	type BulkEditEntitiesToCollection,
+	useBulkEditCollection,
+} from "~/lib/state/collection";
+import { CollectionTemplateRenderer } from "./CollectionTemplateRenderer";
+
+export interface BulkCollectionEditingAffixProps {
+	bulkAddEntities: BulkEditEntitiesToCollection;
+}
+
+export const BulkCollectionEditingAffix = (
+	props: BulkCollectionEditingAffixProps,
+) => {
+	const bulkEditingCollection = useBulkEditCollection();
+	const addEntitiesToCollection = useAddEntitiesToCollectionMutation();
+	const removeEntitiesFromCollection =
+		useRemoveEntitiesFromCollectionMutation();
+	const userCollections = useUserCollections();
+	const [bulkExtraInformation, setBulkExtraInformation] = useState<
+		Record<string, unknown>
+	>({});
+	const [
+		extraInformationModalOpened,
+		{ open: openExtraInformationModal, close: closeExtraInformationModal },
+	] = useDisclosure(false);
+	const { formRef, isFormValid } = useFormValidation([bulkExtraInformation]);
+
+	const bulkEditingCollectionState = bulkEditingCollection.state;
+
+	if (!bulkEditingCollectionState) return null;
+
+	const { action, collection, targetEntities } =
+		bulkEditingCollectionState.data;
+	const isRemoving = action === "remove";
+	const collectionDetails = userCollections.find((c) => c.id === collection.id);
+	const requiresExtraInformation =
+		!isRemoving && !!collectionDetails?.informationTemplate?.length;
+
+	const resetExtraInformation = () => setBulkExtraInformation({});
+
+	const buildPayloadEntities = (
+		information?: Scalars["JSON"]["input"],
+	): EntityToCollectionInput[] =>
+		targetEntities.map((entity) => {
+			const payload: EntityToCollectionInput = {
+				entityId: entity.entityId,
+				entityLot: entity.entityLot,
+			};
+			if (!isRemoving && information && Object.keys(information).length > 0) {
+				payload.information = information;
+			}
+			return payload;
+		});
+
+	const handleBulkAction = async (information?: Scalars["JSON"]["input"]) => {
+		const mutation = isRemoving
+			? removeEntitiesFromCollection
+			: addEntitiesToCollection;
+		const actionText = isRemoving ? "Removing" : "Adding";
+
+		await mutation.mutateAsync({
+			collectionName: collection.name,
+			creatorUserId: collection.creatorUserId,
+			entities: buildPayloadEntities(information),
+		});
+
+		notifications.show({
+			color: "green",
+			title: "Success",
+			message: `${actionText} ${targetEntities.length} item${targetEntities.length === 1 ? "" : "s"} ${isRemoving ? "from" : "to"} collection`,
+		});
+
+		resetExtraInformation();
+		bulkEditingCollectionState.stop();
+	};
+
+	const getConfirmationMessage = () => {
+		const itemCount = targetEntities.length;
+		return `Are you sure you want to ${action} ${itemCount} item${itemCount === 1 ? "" : "s"} ${isRemoving ? "from" : "to"} "${collection.name}"?`;
+	};
+
+	const handleConfirmBulkAction = () => {
+		if (requiresExtraInformation) {
+			openExtraInformationModal();
+			return;
+		}
+		openConfirmationModal(getConfirmationMessage(), () => {
+			void handleBulkAction();
+		});
+	};
+
+	const closeExtraInformation = () => {
+		closeExtraInformationModal();
+		resetExtraInformation();
+	};
+
+	const handleExtraInformationSubmit = (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const information = bulkExtraInformation;
+		openConfirmationModal(getConfirmationMessage(), async () => {
+			handleBulkAction(information).then(() => closeExtraInformation());
+		});
+	};
+
+	const isLoading =
+		addEntitiesToCollection.isPending || removeEntitiesFromCollection.isPending;
+
+	return (
+		<>
+			<Modal
+				centered
+				opened={extraInformationModalOpened}
+				onClose={closeExtraInformation}
+				title={`Add extra information to "${collection.name}"`}
+			>
+				<form ref={formRef} onSubmit={handleExtraInformationSubmit}>
+					<Stack>
+						<Text size="sm" c="dimmed">
+							The details below will be applied to all selected items.
+						</Text>
+						{collectionDetails?.informationTemplate?.map((template) => (
+							<CollectionTemplateRenderer
+								key={template.name}
+								template={template}
+								value={bulkExtraInformation[template.name]}
+								onChange={(value) =>
+									setBulkExtraInformation((prev) => ({
+										...prev,
+										[template.name]: value,
+									}))
+								}
+							/>
+						))}
+						<Group justify="flex-end">
+							<Button
+								type="button"
+								variant="subtle"
+								onClick={closeExtraInformation}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								variant="outline"
+								loading={isLoading}
+								disabled={!isFormValid || targetEntities.length === 0}
+							>
+								{changeCase(action)}
+							</Button>
+						</Group>
+					</Stack>
+				</form>
+			</Modal>
+			<Affix position={{ bottom: rem(30) }} w="100%" px="sm">
+				<Paper withBorder shadow="xl" p="md" w={{ md: "40%" }} mx="auto">
+					<Group wrap="nowrap" justify="space-between">
+						<Text fz={{ base: "xs", md: "md" }}>
+							{targetEntities.length} items selected
+						</Text>
+						<Group wrap="nowrap">
+							<ActionIcon
+								size="md"
+								onClick={() => bulkEditingCollectionState.stop()}
+							>
+								<IconCancel />
+							</ActionIcon>
+							<Button
+								size="xs"
+								color="blue"
+								loading={bulkEditingCollectionState.data.isLoading}
+								onClick={() =>
+									bulkEditingCollectionState.bulkAdd(props.bulkAddEntities)
+								}
+							>
+								Select all items
+							</Button>
+							<Button
+								size="xs"
+								loading={isLoading}
+								onClick={handleConfirmBulkAction}
+								color={isRemoving ? "red" : "green"}
+								disabled={
+									targetEntities.length === 0 ||
+									(!isRemoving && !collectionDetails)
+								}
+							>
+								{changeCase(action)}
+							</Button>
+						</Group>
+					</Group>
+				</Paper>
+			</Affix>
+		</>
+	);
+};

--- a/apps/frontend/app/components/common/CollectionTemplateRenderer.tsx
+++ b/apps/frontend/app/components/common/CollectionTemplateRenderer.tsx
@@ -1,0 +1,86 @@
+import { NumberInput, Switch, TextInput } from "@mantine/core";
+import { DateInput, DateTimePicker } from "@mantine/dates";
+import {
+	type CollectionExtraInformation,
+	CollectionExtraInformationLot,
+	type Scalars,
+} from "@ryot/generated/graphql/backend/graphql";
+import { match } from "ts-pattern";
+import { dayjsLib } from "~/lib/shared/date-utils";
+import { MultiSelectCreatable } from "./multi-select-creatable";
+
+export interface CollectionTemplateRendererProps {
+	value: Scalars["JSON"]["input"];
+	template: CollectionExtraInformation;
+	onChange: (value: Scalars["JSON"]["input"]) => void;
+}
+
+export const CollectionTemplateRenderer = (
+	props: CollectionTemplateRendererProps,
+) => (
+	<>
+		{match(props.template.lot)
+			.with(CollectionExtraInformationLot.String, () => (
+				<TextInput
+					value={props.value || ""}
+					label={props.template.name}
+					required={!!props.template.required}
+					description={props.template.description}
+					onChange={(e) => props.onChange(e.currentTarget.value)}
+				/>
+			))
+			.with(CollectionExtraInformationLot.Boolean, () => (
+				<Switch
+					label={props.template.name}
+					checked={props.value === "true"}
+					required={!!props.template.required}
+					description={props.template.description}
+					onChange={(e) =>
+						props.onChange(e.currentTarget.checked ? "true" : "false")
+					}
+				/>
+			))
+			.with(CollectionExtraInformationLot.Number, () => (
+				<NumberInput
+					value={props.value}
+					label={props.template.name}
+					required={!!props.template.required}
+					description={props.template.description}
+					onChange={(v) => props.onChange(v)}
+				/>
+			))
+			.with(CollectionExtraInformationLot.Date, () => (
+				<DateInput
+					clearable
+					value={props.value}
+					label={props.template.name}
+					required={!!props.template.required}
+					description={props.template.description}
+					onChange={(v) => props.onChange(v)}
+				/>
+			))
+			.with(CollectionExtraInformationLot.DateTime, () => (
+				<DateTimePicker
+					clearable
+					value={props.value}
+					label={props.template.name}
+					required={!!props.template.required}
+					description={props.template.description}
+					onChange={(v) =>
+						props.onChange(v ? dayjsLib(v).toISOString() : undefined)
+					}
+				/>
+			))
+			.with(CollectionExtraInformationLot.StringArray, () => (
+				<MultiSelectCreatable
+					values={props.value}
+					label={props.template.name}
+					required={!!props.template.required}
+					description={props.template.description}
+					data={props.template.possibleValues || []}
+					setValue={(newValue: string[]) => props.onChange(newValue)}
+				/>
+			))
+			.exhaustive()}
+	</>
+);

--- a/apps/frontend/app/components/common/index.tsx
+++ b/apps/frontend/app/components/common/index.tsx
@@ -456,9 +456,8 @@ export const BulkCollectionEditingAffix = (props: {
 	const handleExtraInformationSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		const information = bulkExtraInformation;
-		openConfirmationModal(getConfirmationMessage(), () => {
-			closeExtraInformation();
-			void handleBulkAction(information);
+		openConfirmationModal(getConfirmationMessage(), async () => {
+			handleBulkAction(information).then(() => closeExtraInformation());
 		});
 	};
 

--- a/apps/frontend/app/components/common/index.tsx
+++ b/apps/frontend/app/components/common/index.tsx
@@ -376,7 +376,7 @@ export const BulkCollectionEditingAffix = (props: {
 		useRemoveEntitiesFromCollectionMutation();
 	const userCollections = useUserCollections();
 	const [bulkExtraInformation, setBulkExtraInformation] = useState<
-		Scalars["JSON"]["input"]
+		Record<string, unknown>
 	>({});
 	const [
 		extraInformationModalOpened,
@@ -484,7 +484,7 @@ export const BulkCollectionEditingAffix = (props: {
 								template={template}
 								value={bulkExtraInformation[template.name]}
 								onChange={(value) =>
-									setBulkExtraInformation((prev: Scalars["JSON"]["input"]) => ({
+									setBulkExtraInformation((prev) => ({
 										...prev,
 										[template.name]: value,
 									}))

--- a/apps/frontend/app/components/common/index.tsx
+++ b/apps/frontend/app/components/common/index.tsx
@@ -537,8 +537,11 @@ export const BulkCollectionEditingAffix = (props: {
 								size="xs"
 								loading={isLoading}
 								onClick={handleConfirmBulkAction}
-								disabled={targetEntities.length === 0}
 								color={isRemoving ? "red" : "green"}
+								disabled={
+									targetEntities.length === 0 ||
+									(!isRemoving && !collectionDetails)
+								}
 							>
 								{changeCase(action)}
 							</Button>

--- a/apps/frontend/app/components/routes/dashboard/forms/add-entity-to-collections-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/add-entity-to-collections-form.tsx
@@ -12,7 +12,7 @@ import { Form } from "react-router";
 import { Fragment } from "react/jsx-runtime";
 import invariant from "tiny-invariant";
 import { match } from "ts-pattern";
-import { CollectionTemplateRenderer } from "~/components/common";
+import { CollectionTemplateRenderer } from "~/components/common/CollectionTemplateRenderer";
 import {
 	useAddEntitiesToCollectionMutation,
 	useApplicationEvents,

--- a/apps/frontend/app/components/routes/dashboard/forms/edit-entity-collection-information-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/edit-entity-collection-information-form.tsx
@@ -3,7 +3,7 @@ import { notifications } from "@mantine/notifications";
 import type { Scalars } from "@ryot/generated/graphql/backend/graphql";
 import { type FormEvent, useState } from "react";
 import { Form } from "react-router";
-import { CollectionTemplateRenderer } from "~/components/common";
+import { CollectionTemplateRenderer } from "~/components/common/CollectionTemplateRenderer";
 import {
 	useAddEntitiesToCollectionMutation,
 	useApplicationEvents,

--- a/apps/frontend/app/lib/state/collection.ts
+++ b/apps/frontend/app/lib/state/collection.ts
@@ -74,7 +74,10 @@ export const useBulkEditCollection = () => {
 					remove: (toRemove: Entity) => {
 						setBec(
 							produce(bec, (draft) => {
-								draft.targetEntities.splice(findIndex(toRemove), 1);
+								draft.targetEntities.splice(
+									findIndex(toRemove, bec.targetEntities),
+									1,
+								);
 							}),
 						);
 					},

--- a/apps/frontend/app/lib/state/collection.ts
+++ b/apps/frontend/app/lib/state/collection.ts
@@ -82,7 +82,7 @@ export const useBulkEditCollection = () => {
 						);
 					},
 					add: (toAdd: Entity) => {
-						if (findIndex(toAdd) !== -1) return;
+						if (findIndex(toAdd, bec.targetEntities) !== -1) return;
 						setBec(
 							produce(bec, (draft) => {
 								draft.targetEntities.push(toAdd);

--- a/apps/frontend/app/lib/state/collection.ts
+++ b/apps/frontend/app/lib/state/collection.ts
@@ -72,12 +72,11 @@ export const useBulkEditCollection = () => {
 						setBec({ ...bec, isLoading: false, targetEntities: entities });
 					},
 					remove: (toRemove: Entity) => {
+						const index = findIndex(toRemove, bec.targetEntities);
+						if (index === -1) return;
 						setBec(
 							produce(bec, (draft) => {
-								draft.targetEntities.splice(
-									findIndex(toRemove, bec.targetEntities),
-									1,
-								);
+								draft.targetEntities.splice(index, 1);
 							}),
 						);
 					},

--- a/apps/frontend/app/routes/_dashboard.collections.$id._index.tsx
+++ b/apps/frontend/app/routes/_dashboard.collections.$id._index.tsx
@@ -47,11 +47,11 @@ import invariant from "tiny-invariant";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	ApplicationPagination,
-	BulkCollectionEditingAffix,
 	DisplayCollectionEntity,
 	DisplayListDetailsAndRefresh,
 	SkeletonLoader,
 } from "~/components/common";
+import { BulkCollectionEditingAffix } from "~/components/common/BulkCollectionEditingAffix";
 import {
 	DebouncedSearchInput,
 	FiltersModal,

--- a/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
@@ -452,8 +452,8 @@ const DisplayFitnessEntity = (props: {
 						bulkEditingState.data.action === "add" &&
 						!isAlreadyPresent ? (
 							<ActionIcon
-								variant={isAdded ? "filled" : "transparent"}
 								color="green"
+								variant={isAdded ? "filled" : "outline"}
 								onClick={() => {
 									if (isAdded) bulkEditingState.remove(becItem);
 									else bulkEditingState.add(becItem);

--- a/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
@@ -454,6 +454,7 @@ const DisplayFitnessEntity = (props: {
 							<ActionIcon
 								color="green"
 								variant={isAdded ? "filled" : "outline"}
+								disabled={bulkEditingState.data.isLoading}
 								onClick={() => {
 									if (isAdded) bulkEditingState.remove(becItem);
 									else bulkEditingState.add(becItem);

--- a/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
@@ -50,10 +50,10 @@ import { match } from "ts-pattern";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	ApplicationPagination,
-	BulkCollectionEditingAffix,
 	DisplayListDetailsAndRefresh,
 	SkeletonLoader,
 } from "~/components/common";
+import { BulkCollectionEditingAffix } from "~/components/common/BulkCollectionEditingAffix";
 import {
 	DebouncedSearchInput,
 	FiltersModal,

--- a/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
@@ -17,6 +17,7 @@ import {
 import { useDisclosure, useInViewport } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import {
+	EntityLot,
 	GraphqlSortOrder,
 	type UserTemplatesOrWorkoutsListInput,
 	UserTemplatesOrWorkoutsListSortBy,
@@ -28,6 +29,7 @@ import {
 } from "@ryot/generated/graphql/backend/graphql";
 import { changeCase, humanizeDuration, truncate } from "@ryot/ts-utils";
 import {
+	IconCheck,
 	IconChevronDown,
 	IconChevronUp,
 	IconClock,
@@ -48,6 +50,7 @@ import { match } from "ts-pattern";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	ApplicationPagination,
+	BulkCollectionEditingAffix,
 	DisplayListDetailsAndRefresh,
 	SkeletonLoader,
 } from "~/components/common";
@@ -74,6 +77,7 @@ import {
 	convertEnumToSelectData,
 	isFilterChanged,
 } from "~/lib/shared/ui-utils";
+import { useBulkEditCollection } from "~/lib/state/collection";
 import { getDefaultWorkout } from "~/lib/state/fitness";
 import {
 	OnboardingTourStepTargets,
@@ -103,6 +107,36 @@ export const meta = () => {
 	return [{ title: "Fitness Entity List | Ryot" }];
 };
 
+const useBulkEditingState = () => {
+	const bulkEditingCollection = useBulkEditCollection();
+	return bulkEditingCollection.state === false
+		? null
+		: bulkEditingCollection.state;
+};
+
+const buildQueryInput = (
+	filters: FilterState,
+	overrides?: Partial<UserTemplatesOrWorkoutsListInput>,
+): UserTemplatesOrWorkoutsListInput => {
+	const baseInput: UserTemplatesOrWorkoutsListInput = {
+		sort: { by: filters.sortBy, order: filters.orderBy },
+		search: { query: filters.query, page: filters.page },
+	};
+
+	if (overrides) {
+		return {
+			...baseInput,
+			...overrides,
+			search: {
+				...baseInput.search,
+				...overrides.search,
+			},
+		};
+	}
+
+	return baseInput;
+};
+
 export default function Page(props: { params: { entity: FitnessEntity } }) {
 	const { entity } = props.params;
 	invariant(entity);
@@ -118,14 +152,12 @@ export default function Page(props: { params: { entity: FitnessEntity } }) {
 		{ open: openFiltersModal, close: closeFiltersModal },
 	] = useDisclosure(false);
 	const { advanceOnboardingTourStep } = useOnboardingTour();
+	const bulkEditingState = useBulkEditingState();
 
 	const updateFilter: FilterUpdateFunction<FilterState> = (key, value) =>
 		setFilters((prev) => ({ ...prev, [key]: value }));
 
-	const input: UserTemplatesOrWorkoutsListInput = {
-		sort: { by: filters.sortBy, order: filters.orderBy },
-		search: { query: filters.query, page: filters.page },
-	};
+	const input = buildQueryInput(filters);
 	const { data: listData, refetch: refetchListData } = useQuery({
 		queryKey: queryFactory.fitness.entityList(entity, input).queryKey,
 		queryFn: () =>
@@ -154,98 +186,128 @@ export default function Page(props: { params: { entity: FitnessEntity } }) {
 	const areListFiltersActive = isFilterChanged(filters, defaultFilterState);
 
 	return (
-		<Container size="xs">
-			<Stack>
-				<WorkoutRevisionScheduledAlert />
-				<Flex align="center" gap="md">
-					<Title>{changeCase(entity)}</Title>
-					<ActionIcon
-						color="green"
-						variant="outline"
-						className={OnboardingTourStepTargets.AddNewWorkout}
-						onClick={async () => {
-							if (
-								!coreDetails.isServerKeyValidated &&
-								entity === FitnessEntity.Templates
-							) {
-								notifications.show({
-									color: "red",
-									message: PRO_REQUIRED_MESSAGE,
-								});
-								return;
-							}
-							const action = match(entity)
-								.with(FitnessEntity.Workouts, () => FitnessAction.LogWorkout)
-								.with(
-									FitnessEntity.Templates,
-									() => FitnessAction.CreateTemplate,
-								)
-								.exhaustive();
-							advanceOnboardingTourStep();
-							startWorkout(getDefaultWorkout(action), action);
-						}}
-					>
-						<IconPlus size={16} />
-					</ActionIcon>
-				</Flex>
-				<Group wrap="nowrap">
-					<DebouncedSearchInput
-						value={filters.query}
-						onChange={(value) => {
-							updateFilter("query", value);
-							updateFilter("page", 1);
-						}}
-						placeholder={`Search for ${entity}`}
-					/>
-					<ActionIcon
-						onClick={openFiltersModal}
-						color={areListFiltersActive ? "blue" : "gray"}
-					>
-						<IconFilter size={24} />
-					</ActionIcon>
-					<FiltersModal
-						opened={filtersModalOpened}
-						closeFiltersModal={closeFiltersModal}
-						resetFilters={() => setFilters(defaultFilterState)}
-					>
-						<FiltersModalForm filters={filters} updateFilter={updateFilter} />
-					</FiltersModal>
-				</Group>
-				<Stack gap="xs">
-					{listData ? (
-						<>
-							<DisplayListDetailsAndRefresh
-								cacheId={listData.cacheId}
-								onRefreshButtonClicked={refetchListData}
-								total={listData.details.totalItems}
-								isRandomSortOrderSelected={
-									filters.sortBy === UserTemplatesOrWorkoutsListSortBy.Random
+		<>
+			<BulkCollectionEditingAffix
+				bulkAddEntities={async () => {
+					if (bulkEditingState?.data.action !== "add") return [];
+					const queryInput = buildQueryInput(filters, {
+						search: { page: 1, take: Number.MAX_SAFE_INTEGER },
+					});
+
+					if (entity === FitnessEntity.Workouts) {
+						const { userWorkoutsList } = await clientGqlService.request(
+							UserWorkoutsListDocument,
+							{ input: queryInput },
+						);
+						return userWorkoutsList.response.items.map((workoutId) => ({
+							entityId: workoutId,
+							entityLot: EntityLot.Workout,
+						}));
+					}
+
+					const { userWorkoutTemplatesList } = await clientGqlService.request(
+						UserWorkoutTemplatesListDocument,
+						{ input: queryInput },
+					);
+					return userWorkoutTemplatesList.response.items.map((templateId) => ({
+						entityId: templateId,
+						entityLot: EntityLot.WorkoutTemplate,
+					}));
+				}}
+			/>
+			<Container size="xs">
+				<Stack>
+					<WorkoutRevisionScheduledAlert />
+					<Flex align="center" gap="md">
+						<Title>{changeCase(entity)}</Title>
+						<ActionIcon
+							color="green"
+							variant="outline"
+							className={OnboardingTourStepTargets.AddNewWorkout}
+							onClick={async () => {
+								if (
+									!coreDetails.isServerKeyValidated &&
+									entity === FitnessEntity.Templates
+								) {
+									notifications.show({
+										color: "red",
+										message: PRO_REQUIRED_MESSAGE,
+									});
+									return;
 								}
-							/>
-							{listData.items.length > 0 ? (
-								listData.items.map((entityId, index) => (
-									<DisplayFitnessEntity
-										index={index}
-										key={entityId}
-										entity={entity}
-										entityId={entityId}
-									/>
-								))
-							) : (
-								<Text>No {entity} found</Text>
-							)}
-							<ApplicationPagination
-								value={filters.page}
-								totalItems={listData.details.totalItems}
-								onChange={(v) => updateFilter("page", v)}
-							/>
-						</>
-					) : (
-						<SkeletonLoader />
-					)}
+								const action = match(entity)
+									.with(FitnessEntity.Workouts, () => FitnessAction.LogWorkout)
+									.with(
+										FitnessEntity.Templates,
+										() => FitnessAction.CreateTemplate,
+									)
+									.exhaustive();
+								advanceOnboardingTourStep();
+								startWorkout(getDefaultWorkout(action), action);
+							}}
+						>
+							<IconPlus size={16} />
+						</ActionIcon>
+					</Flex>
+					<Group wrap="nowrap">
+						<DebouncedSearchInput
+							value={filters.query}
+							onChange={(value) => {
+								updateFilter("query", value);
+								updateFilter("page", 1);
+							}}
+							placeholder={`Search for ${entity}`}
+						/>
+						<ActionIcon
+							onClick={openFiltersModal}
+							color={areListFiltersActive ? "blue" : "gray"}
+						>
+							<IconFilter size={24} />
+						</ActionIcon>
+						<FiltersModal
+							opened={filtersModalOpened}
+							closeFiltersModal={closeFiltersModal}
+							resetFilters={() => setFilters(defaultFilterState)}
+						>
+							<FiltersModalForm filters={filters} updateFilter={updateFilter} />
+						</FiltersModal>
+					</Group>
+					<Stack gap="xs">
+						{listData ? (
+							<>
+								<DisplayListDetailsAndRefresh
+									cacheId={listData.cacheId}
+									onRefreshButtonClicked={refetchListData}
+									total={listData.details.totalItems}
+									isRandomSortOrderSelected={
+										filters.sortBy === UserTemplatesOrWorkoutsListSortBy.Random
+									}
+								/>
+								{listData.items.length > 0 ? (
+									listData.items.map((entityId, index) => (
+										<DisplayFitnessEntity
+											index={index}
+											key={entityId}
+											entity={entity}
+											entityId={entityId}
+										/>
+									))
+								) : (
+									<Text>No {entity} found</Text>
+								)}
+								<ApplicationPagination
+									value={filters.page}
+									totalItems={listData.details.totalItems}
+									onChange={(v) => updateFilter("page", v)}
+								/>
+							</>
+						) : (
+							<SkeletonLoader />
+						)}
+					</Stack>
 				</Stack>
-			</Stack>
-		</Container>
+			</Container>
+		</>
 	);
 }
 
@@ -258,6 +320,15 @@ const DisplayFitnessEntity = (props: {
 	const { ref, inViewport } = useInViewport();
 	const [parent] = useAutoAnimate();
 	const [showDetails, setShowDetails] = useDisclosure(false);
+	const bulkEditingCollection = useBulkEditCollection();
+	const bulkEditingState = useBulkEditingState();
+	const entityLot =
+		props.entity === FitnessEntity.Workouts
+			? EntityLot.Workout
+			: EntityLot.WorkoutTemplate;
+	const becItem = { entityId: props.entityId, entityLot };
+	const isAlreadyPresent = bulkEditingCollection.isAlreadyPresent(becItem);
+	const isAdded = bulkEditingCollection.isAdded(becItem);
 
 	const { data: entityInformation } = useQuery({
 		enabled: inViewport,
@@ -376,13 +447,29 @@ const DisplayFitnessEntity = (props: {
 							) : null}
 						</Group>
 					</Box>
-					<ActionIcon onClick={() => setShowDetails.toggle()}>
-						{showDetails ? (
-							<IconChevronUp size={16} />
-						) : (
-							<IconChevronDown size={16} />
-						)}
-					</ActionIcon>
+					<Group wrap="nowrap" gap="xs">
+						{bulkEditingState &&
+						bulkEditingState.data.action === "add" &&
+						!isAlreadyPresent ? (
+							<ActionIcon
+								variant={isAdded ? "filled" : "transparent"}
+								color="green"
+								onClick={() => {
+									if (isAdded) bulkEditingState.remove(becItem);
+									else bulkEditingState.add(becItem);
+								}}
+							>
+								<IconCheck size={16} />
+							</ActionIcon>
+						) : null}
+						<ActionIcon onClick={() => setShowDetails.toggle()}>
+							{showDetails ? (
+								<IconChevronUp size={16} />
+							) : (
+								<IconChevronDown size={16} />
+							)}
+						</ActionIcon>
+					</Group>
 				</Group>
 				{repsData.length >= 3 ? (
 					<Sparkline h="60" data={repsData} color="teal" />

--- a/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
@@ -572,7 +572,7 @@ const ExerciseItemDisplay = (props: {
 						<ActionIcon
 							ml="auto"
 							color="green"
-							variant={isAdded ? "filled" : "transparent"}
+							variant={isAdded ? "filled" : "outline"}
 							onClick={() => {
 								if (isAdded) bulkEditingState.remove(becItem);
 								else bulkEditingState.add(becItem);

--- a/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
@@ -60,10 +60,10 @@ import { useLocalStorage } from "usehooks-ts";
 import { z } from "zod";
 import {
 	ApplicationPagination,
-	BulkCollectionEditingAffix,
 	DisplayListDetailsAndRefresh,
 	SkeletonLoader,
 } from "~/components/common";
+import { BulkCollectionEditingAffix } from "~/components/common/BulkCollectionEditingAffix";
 import {
 	DebouncedSearchInput,
 	FiltersModal,

--- a/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
@@ -213,139 +213,141 @@ export default function Page() {
 		setFilters((prev) => ({ ...prev, [key]: value }));
 
 	return (
-		<Container size="md">
-			<Stack>
-				<Flex align="center" gap="md">
-					<Title>Exercises</Title>
-					<ActionIcon
-						color="green"
-						component={Link}
-						variant="outline"
-						to={$path("/fitness/exercises/update/:action", {
-							action: "create",
-						})}
-					>
-						<IconPlus size={16} />
-					</ActionIcon>
-				</Flex>
-				<Group wrap="nowrap">
-					<DebouncedSearchInput
-						value={filters.query}
-						placeholder="Search for exercises by name or instructions"
-						onChange={(value) => {
-							updateFilter("query", value);
-							updateFilter("page", 1);
-						}}
-						tourControl={{
-							target: OnboardingTourStepTargets.SearchForExercise,
-							onQueryChange: (query) => {
-								if (query === TOUR_EXERCISE_TARGET_ID.toLowerCase()) {
-									advanceOnboardingTourStep();
-								}
-							},
-						}}
-					/>
-					<ActionIcon
-						onClick={openFiltersModal}
-						color={areListFiltersActive ? "blue" : "gray"}
-					>
-						<IconFilter size={24} />
-					</ActionIcon>
-					<FiltersModal
-						opened={filtersModalOpened}
-						closeFiltersModal={closeFiltersModal}
-						resetFilters={() => setFilters(defaultFilters)}
-					>
-						<FiltersModalForm filter={filters} updateFilter={updateFilter} />
-					</FiltersModal>
-				</Group>
-				{currentWorkout?.replacingExerciseIdx ? (
-					<Alert icon={<IconAlertCircle />}>
-						You are replacing exercise: {replacingExercise?.name}
-					</Alert>
-				) : null}
-				{mergingExercise ? (
-					<Alert icon={<IconAlertCircle />}>
-						You are merging exercise: {mergingExercise}
-					</Alert>
-				) : null}
-				{userExercisesList ? (
-					<>
-						{userExercisesList.response.details.totalItems > 0 ? (
-							<>
-								<DisplayListDetailsAndRefresh
-									cacheId={userExercisesList.cacheId}
-									onRefreshButtonClicked={refetchUserExercisesList}
-									total={userExercisesList.response.details.totalItems}
-									isRandomSortOrderSelected={
-										filters.sortBy === ExerciseSortBy.Random
+		<>
+			<Container size="md">
+				<Stack>
+					<Flex align="center" gap="md">
+						<Title>Exercises</Title>
+						<ActionIcon
+							color="green"
+							component={Link}
+							variant="outline"
+							to={$path("/fitness/exercises/update/:action", {
+								action: "create",
+							})}
+						>
+							<IconPlus size={16} />
+						</ActionIcon>
+					</Flex>
+					<Group wrap="nowrap">
+						<DebouncedSearchInput
+							value={filters.query}
+							placeholder="Search for exercises by name or instructions"
+							onChange={(value) => {
+								updateFilter("query", value);
+								updateFilter("page", 1);
+							}}
+							tourControl={{
+								target: OnboardingTourStepTargets.SearchForExercise,
+								onQueryChange: (query) => {
+									if (query === TOUR_EXERCISE_TARGET_ID.toLowerCase()) {
+										advanceOnboardingTourStep();
 									}
-									rightSection={
-										allowAddingExerciseToWorkout ? (
-											<>
-												{" "}
-												and{" "}
-												<Text display="inline" fw="bold">
-													{selectedExercises.length}
-												</Text>{" "}
-												selected
-											</>
-										) : null
-									}
-								/>
-								<SimpleGrid cols={{ md: 2, lg: 3 }}>
-									{userExercisesList.response.items.map((exercise) => (
-										<ExerciseItemDisplay
-											key={exercise}
-											exerciseId={exercise}
-											mergingExercise={mergingExercise}
-											setMergingExercise={setMergingExercise}
-											setSelectedExercises={setSelectedExercises}
-											allowAddingExerciseToWorkout={
-												allowAddingExerciseToWorkout
-											}
-										/>
-									))}
-								</SimpleGrid>
-							</>
-						) : (
-							<Text>No information to display</Text>
-						)}
-						<ApplicationPagination
-							value={filters.page}
-							onChange={(v) => updateFilter("page", v)}
-							totalItems={userExercisesList.response.details.totalItems}
+								},
+							}}
 						/>
-					</>
-				) : (
-					<SkeletonLoader />
-				)}
-			</Stack>
-			{allowAddingExerciseToWorkout ? (
-				<Affix position={{ bottom: rem(40), right: rem(30) }}>
-					<ActionIcon
-						size="xl"
-						radius="xl"
-						color="blue"
-						variant="light"
-						disabled={selectedExercises.length === 0}
-						className={OnboardingTourStepTargets.AddSelectedExerciseToWorkout}
-						onClick={async () => {
-							await addExerciseToCurrentWorkout(
-								navigate,
-								currentWorkout,
-								userPreferences.fitness,
-								setCurrentWorkout,
-								selectedExercises,
-							);
-							advanceOnboardingTourStep();
-						}}
-					>
-						<IconCheck size={32} />
-					</ActionIcon>
-				</Affix>
-			) : null}
-		</Container>
+						<ActionIcon
+							onClick={openFiltersModal}
+							color={areListFiltersActive ? "blue" : "gray"}
+						>
+							<IconFilter size={24} />
+						</ActionIcon>
+						<FiltersModal
+							opened={filtersModalOpened}
+							closeFiltersModal={closeFiltersModal}
+							resetFilters={() => setFilters(defaultFilters)}
+						>
+							<FiltersModalForm filter={filters} updateFilter={updateFilter} />
+						</FiltersModal>
+					</Group>
+					{currentWorkout?.replacingExerciseIdx ? (
+						<Alert icon={<IconAlertCircle />}>
+							You are replacing exercise: {replacingExercise?.name}
+						</Alert>
+					) : null}
+					{mergingExercise ? (
+						<Alert icon={<IconAlertCircle />}>
+							You are merging exercise: {mergingExercise}
+						</Alert>
+					) : null}
+					{userExercisesList ? (
+						<>
+							{userExercisesList.response.details.totalItems > 0 ? (
+								<>
+									<DisplayListDetailsAndRefresh
+										cacheId={userExercisesList.cacheId}
+										onRefreshButtonClicked={refetchUserExercisesList}
+										total={userExercisesList.response.details.totalItems}
+										isRandomSortOrderSelected={
+											filters.sortBy === ExerciseSortBy.Random
+										}
+										rightSection={
+											allowAddingExerciseToWorkout ? (
+												<>
+													{" "}
+													and{" "}
+													<Text display="inline" fw="bold">
+														{selectedExercises.length}
+													</Text>{" "}
+													selected
+												</>
+											) : null
+										}
+									/>
+									<SimpleGrid cols={{ md: 2, lg: 3 }}>
+										{userExercisesList.response.items.map((exercise) => (
+											<ExerciseItemDisplay
+												key={exercise}
+												exerciseId={exercise}
+												mergingExercise={mergingExercise}
+												setMergingExercise={setMergingExercise}
+												setSelectedExercises={setSelectedExercises}
+												allowAddingExerciseToWorkout={
+													allowAddingExerciseToWorkout
+												}
+											/>
+										))}
+									</SimpleGrid>
+								</>
+							) : (
+								<Text>No information to display</Text>
+							)}
+							<ApplicationPagination
+								value={filters.page}
+								onChange={(v) => updateFilter("page", v)}
+								totalItems={userExercisesList.response.details.totalItems}
+							/>
+						</>
+					) : (
+						<SkeletonLoader />
+					)}
+				</Stack>
+				{allowAddingExerciseToWorkout ? (
+					<Affix position={{ bottom: rem(40), right: rem(30) }}>
+						<ActionIcon
+							size="xl"
+							radius="xl"
+							color="blue"
+							variant="light"
+							disabled={selectedExercises.length === 0}
+							className={OnboardingTourStepTargets.AddSelectedExerciseToWorkout}
+							onClick={async () => {
+								await addExerciseToCurrentWorkout(
+									navigate,
+									currentWorkout,
+									userPreferences.fitness,
+									setCurrentWorkout,
+									selectedExercises,
+								);
+								advanceOnboardingTourStep();
+							}}
+						>
+							<IconCheck size={32} />
+						</ActionIcon>
+					</Affix>
+				) : null}
+			</Container>
+		</>
 	);
 }
 

--- a/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.exercises.list.tsx
@@ -573,6 +573,7 @@ const ExerciseItemDisplay = (props: {
 							ml="auto"
 							color="green"
 							variant={isAdded ? "filled" : "outline"}
+							disabled={bulkEditingState.data.isLoading}
 							onClick={() => {
 								if (isAdded) bulkEditingState.remove(becItem);
 								else bulkEditingState.add(becItem);

--- a/apps/frontend/app/routes/_dashboard.media.$action.$lot.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.$action.$lot.tsx
@@ -44,12 +44,12 @@ import { $path } from "safe-routes";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	ApplicationPagination,
-	BulkCollectionEditingAffix,
 	CreateButton,
 	DisplayListDetailsAndRefresh,
 	ProRequiredAlert,
 	SkeletonLoader,
 } from "~/components/common";
+import { BulkCollectionEditingAffix } from "~/components/common/BulkCollectionEditingAffix";
 import {
 	CollectionsFilter,
 	DebouncedSearchInput,

--- a/apps/frontend/app/routes/_dashboard.media.groups.$action.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.groups.$action.tsx
@@ -39,11 +39,11 @@ import { $path } from "safe-routes";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	ApplicationPagination,
-	BulkCollectionEditingAffix,
 	CreateButton,
 	DisplayListDetailsAndRefresh,
 	SkeletonLoader,
 } from "~/components/common";
+import { BulkCollectionEditingAffix } from "~/components/common/BulkCollectionEditingAffix";
 import {
 	CollectionsFilter,
 	DebouncedSearchInput,

--- a/apps/frontend/app/routes/_dashboard.media.item.$id._index.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.item.$id._index.tsx
@@ -882,11 +882,11 @@ export default function Page() {
 											</Menu.Target>
 											<Menu.Dropdown>
 												<ToggleMediaMonitorMenuItem
+													entityLot={EntityLot.Metadata}
+													formValue={loaderData.metadataId}
 													inCollections={userMetadataDetails.data.collections.map(
 														(c) => c.details.collectionName,
 													)}
-													formValue={loaderData.metadataId}
-													entityLot={EntityLot.Metadata}
 												/>
 												<Menu.Item onClick={mergeMetadataModalOpen}>
 													Merge media

--- a/apps/frontend/app/routes/_dashboard.media.people.$action.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.people.$action.tsx
@@ -39,11 +39,11 @@ import { $path } from "safe-routes";
 import { useLocalStorage } from "usehooks-ts";
 import {
 	ApplicationPagination,
-	BulkCollectionEditingAffix,
 	CreateButton,
 	DisplayListDetailsAndRefresh,
 	SkeletonLoader,
 } from "~/components/common";
+import { BulkCollectionEditingAffix } from "~/components/common/BulkCollectionEditingAffix";
 import {
 	CollectionsFilter,
 	DebouncedSearchInput,

--- a/crates/utils/dependent/entity/src/lib.rs
+++ b/crates/utils/dependent/entity/src/lib.rs
@@ -218,7 +218,7 @@ pub async fn change_metadata_associations(
 
 pub async fn insert_metadata_person_links(
     ss: &Arc<SupportingService>,
-    metadata_id: &String,
+    metadata_id: &str,
     links: Vec<(String, String, Option<String>, Option<i32>)>,
 ) -> Result<()> {
     for (person_id, role, character, index) in links.into_iter() {
@@ -227,7 +227,7 @@ pub async fn insert_metadata_person_links(
             index: ActiveValue::Set(index),
             person_id: ActiveValue::Set(person_id),
             character: ActiveValue::Set(character),
-            metadata_id: ActiveValue::Set(metadata_id.clone()),
+            metadata_id: ActiveValue::Set(metadata_id.to_owned()),
         };
         intermediate.insert(&ss.db).await.ok();
     }
@@ -236,13 +236,13 @@ pub async fn insert_metadata_person_links(
 
 pub async fn insert_metadata_group_links(
     ss: &Arc<SupportingService>,
-    metadata_id: &String,
+    metadata_id: &str,
     links: Vec<(String, Option<i32>)>,
 ) -> Result<()> {
     for (metadata_group_id, part) in links.into_iter() {
         let intermediate = metadata_to_metadata_group::ActiveModel {
             part: ActiveValue::Set(part.unwrap_or(0)),
-            metadata_id: ActiveValue::Set(metadata_id.clone()),
+            metadata_id: ActiveValue::Set(metadata_id.to_owned()),
             metadata_group_id: ActiveValue::Set(metadata_group_id),
         };
         intermediate.insert(&ss.db).await.ok();


### PR DESCRIPTION
Fixes #1563.

Enhance bulk editing capabilities for fitness entities and exercises, streamline related logic, and update metadata ID type for better consistency. Additionally, include documentation reminders for quoting paths in bash commands. Fix issues with target entity management in bulk editing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Affixed bulk-edit toolbar across Fitness and Exercises with per-item select/deselect, "select all", confirmation, optional per-item extra-info modal, and success notifications.

- Bug Fixes
  - Improved add/remove reliability and duplicate detection for bulk selections.

- Documentation
  - Contributor/setup guidance updated: reference AGENTS.md, quote shell paths, reorder test/run steps, and update example environment version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->