### PR TITLE
Reverse the order of display for measurements graph

### DIFF
--- a/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
@@ -71,7 +71,7 @@ export default function Page() {
 		queryFn: () =>
 			clientGqlService
 				.request(UserMeasurementsListDocument, { input })
-				.then((data) => data.userMeasurementsList),
+				.then((data) => data.userMeasurementsList.response),
 	});
 
 	const deleteUserMeasurementMutation = useMutation({
@@ -103,7 +103,7 @@ export default function Page() {
 		}));
 
 	const formattedData =
-		userMeasurementsList?.response?.map((m) => {
+		userMeasurementsList?.map((m) => {
 			const local: Record<string, string> = {
 				timestamp: m.timestamp,
 				formattedTimestamp: tickFormatter(m.timestamp),
@@ -199,7 +199,7 @@ export default function Page() {
 					</Tabs.Panel>
 				</Tabs>
 				<Text ta="right" mt="xl" fw="bold">
-					{userMeasurementsList?.response?.length || 0} data points
+					{userMeasurementsList?.length || 0} data points
 				</Text>
 			</Stack>
 		</Container>

--- a/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
@@ -17,7 +17,7 @@ import {
 	UserMeasurementsListDocument,
 	type UserMeasurementsListInput,
 } from "@ryot/generated/graphql/backend/graphql";
-import { reverse, startCase } from "@ryot/ts-utils";
+import { cloneDeep, reverse, startCase } from "@ryot/ts-utils";
 import {
 	IconChartArea,
 	IconPlus,
@@ -164,7 +164,7 @@ export default function Page() {
 							borderRadius="sm"
 							withColumnBorders
 							withTableBorder={false}
-							records={reverse(formattedData)}
+							records={reverse(cloneDeep(formattedData))}
 							columns={[
 								{
 									width: 200,

--- a/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
@@ -214,7 +214,7 @@ export default function Page() {
 const calculateYAxisDomain = (data: CompleteData, statValue: string) => {
 	const values = data
 		.map((item) => Number.parseFloat(item[statValue]))
-		.filter((val) => !Number.isFinite(val));
+		.filter((val) => Number.isFinite(val));
 
 	if (values.length === 0) return [0, 100];
 

--- a/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
@@ -52,6 +52,11 @@ export const meta = () => {
 	return [{ title: "Measurements | Ryot" }];
 };
 
+type DataPoint = Record<string, string>;
+type CompleteData = Array<DataPoint>;
+
+const tickFormatter = (date: string) => dayjsLib(date).format("L");
+
 export default function Page() {
 	const userPreferences = useUserPreferences();
 	const [, setMeasurementsDrawerOpen] = useMeasurementsDrawerOpen();
@@ -104,7 +109,7 @@ export default function Page() {
 
 	const formattedData =
 		userMeasurementsList?.map((m) => {
-			const local: Record<string, string> = {
+			const local: DataPoint = {
 				timestamp: m.timestamp,
 				formattedTimestamp: tickFormatter(m.timestamp),
 			};
@@ -206,11 +211,7 @@ export default function Page() {
 	);
 }
 
-const tickFormatter = (date: string) => dayjsLib(date).format("L");
-
-type Data = Array<Record<string, string>>;
-
-const calculateYAxisDomain = (data: Data, statValue: string) => {
+const calculateYAxisDomain = (data: CompleteData, statValue: string) => {
 	const values = data
 		.map((item) => Number.parseFloat(item[statValue]))
 		.filter((val) => !Number.isFinite(val));
@@ -232,7 +233,7 @@ const calculateYAxisDomain = (data: Data, statValue: string) => {
 };
 
 interface SyncedMeasurementChartProps {
-	formattedData: Data;
+	formattedData: CompleteData;
 	stat: { value: string; label: string };
 }
 

--- a/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.measurements.list.tsx
@@ -257,8 +257,8 @@ const SyncedMeasurementChart = (props: SyncedMeasurementChartProps) => {
 					valueFormatter={(val) => Number(val).toFixed(2)}
 					series={[
 						{
-							name: props.stat.value,
 							type: "line",
+							name: props.stat.value,
 							color: generateColor(getStringAsciiValue(props.stat.value)),
 						},
 					]}

--- a/crates/services/user/src/authentication_operations.rs
+++ b/crates/services/user/src/authentication_operations.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use chrono::Utc;
 use common_models::StringIdObject;
@@ -79,7 +79,8 @@ pub async fn login_user(ss: &Arc<SupportingService>, input: AuthUserInput) -> Re
         && let AuthUserInput::Password(PasswordUserInput { password, .. }) = input
     {
         if let Some(hashed_password) = &user.password {
-            let parsed_hash = PasswordHash::new(hashed_password).unwrap();
+            let parsed_hash = PasswordHash::new(hashed_password)
+                .map_err(|_| anyhow!("Invalid password hash format"))?;
             if Argon2::default()
                 .verify_password(password.as_bytes(), &parsed_hash)
                 .is_err()

--- a/crates/traits/src/lib.rs
+++ b/crates/traits/src/lib.rs
@@ -131,7 +131,8 @@ pub trait GraphqlResolverSvc<T: Send + Sync + 'static>: AuthProvider {
 
     async fn svc_and_user<'a>(&self, ctx: &Context<'a>) -> GraphqlResult<(&'a Arc<T>, String)> {
         let (service, user_id) = self.svc_and_maybe_user(ctx).await?;
-        Ok((service, user_id.unwrap()))
+        let user_id = user_id.ok_or_else(|| Error::new(BackendError::NoUserId.to_string()))?;
+        Ok((service, user_id))
     }
 }
 

--- a/crates/utils/dependent/progress/src/lib.rs
+++ b/crates/utils/dependent/progress/src/lib.rs
@@ -308,7 +308,7 @@ pub async fn metadata_progress_update(
             let mut updated_at = previous_seen.updated_at.clone();
 
             if new_progress == progress {
-                bail!("No progress update required");
+                bail!("Update progress is the same as current progress");
             }
             progress = new_progress;
             state = SeenState::InProgress;


### PR DESCRIPTION
Fixes #1575.

Correct handling of the user measurements list response and prevent mutation of formatted data by using `cloneDeep` before reversing the data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Corrected the displayed count of fitness measurements.
  - Prevented list mutation when reversing measurement data to keep displayed lists stable.
  - Replaced unexpected panics with handled errors during authentication and user resolution to improve reliability.

- Refactor
  - Updated frontend data formatting and chart handling to match the backend response shape, improving measurement display and chart accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->