### PR TITLE
Use correct snake-case properties in export schema

### DIFF
--- a/apps/docs/src/includes/export-schema.ts
+++ b/apps/docs/src/includes/export-schema.ts
@@ -48,7 +48,7 @@ export interface CollectionToEntityDetails {
 	created_on: string;
 	creator_user_id: string;
 	information: unknown | null;
-	lastUpdated_on: string;
+	last_updated_on: string;
 	/** The rank of this entity in the collection. This is ignored during importing. */
 	rank?: string;
 }


### PR DESCRIPTION
The properties in export schema were incorrectly camel-cased, fixed it to use correct snake-case properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized exported schema field names to snake_case. Renamed fields: is_hidden, extra_information, default_value, possible_values, information_template, is_default, collection_id, collection_name, created_on, creator_user_id, last_updated_on.

* **Documentation**
  * Updated export schema references and examples to reflect snake_case field names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->