### PR TITLE
Fix OIDC auto-redirect not working when local auth is disabled

### DIFF
--- a/apps/frontend/app/routes/auth.tsx
+++ b/apps/frontend/app/routes/auth.tsx
@@ -59,9 +59,9 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 	const query = parseSearchQuery(request, searchParamsSchema);
 	const [coreDetails] = await Promise.all([getCoreDetails()]);
 	if (
-		(coreDetails.oidcEnabled || true) &&
+		coreDetails.oidcEnabled &&
 		coreDetails.localAuthDisabled &&
-		query.autoOidcLaunch === true
+		query.autoOidcLaunch !== false
 	) {
 		const url = await getOidcRedirectUrl();
 		return redirect(url);


### PR DESCRIPTION
When USERS_DISABLE_LOCAL_AUTH=true is set with OIDC enabled, users were not automatically redirected to the OIDC provider as documented. The loader condition was updated to ensure that auto-redirect occurs by default when visiting /auth, allowing users to escape the redirect only by explicitly setting autoOidcLaunch to false. This change aligns the behavior with the documentation regarding OIDC and local authentication.

Fixes #1600

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authentication flow to properly respect OIDC configuration settings instead of bypassing them.
  * Improved automatic OIDC launch behavior to activate when enabled and not explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->