### PR TITLE
Fix missing field 'data' when adding book via Hardcover

### DIFF
--- a/crates/providers/hardcover/src/provider.rs
+++ b/crates/providers/hardcover/src/provider.rs
@@ -53,8 +53,7 @@ query {{
             .send()
             .await?
             .json::<Response<BooksByPk>>()
-            .await
-            .unwrap();
+            .await?;
         let data = data.data.books_by_pk;
         let mut images = vec![];
         if let Some(i) = data.image
@@ -193,8 +192,7 @@ query {{
             .send()
             .await?
             .json::<Response<SeriesByPk>>()
-            .await
-            .unwrap();
+            .await?;
         let data = data.data.series_by_pk;
         let details = MetadataGroupWithoutId {
             lot: MediaLot::Book,
@@ -284,8 +282,7 @@ query {{
                     .send()
                     .await?
                     .json::<Response<AuthorsByPk>>()
-                    .await
-                    .unwrap();
+                    .await?;
                 let data = data.data.authors_by_pk;
                 let mut images = vec![];
                 if let Some(i) = data.image
@@ -355,8 +352,7 @@ query {{
                     .send()
                     .await?
                     .json::<Response<PublishersByPk>>()
-                    .await
-                    .unwrap();
+                    .await?;
                 let data = data.data.publishers_by_pk;
                 let details = PersonDetails {
                     name: data.name.unwrap(),


### PR DESCRIPTION
Improves error handling by replacing `unwrap()` with `?` in multiple API calls, addressing the issue of a missing 'data' field when adding a book via the Hardcover API. Fixes #1694

Fixes #1694.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling across data retrieval operations to improve overall application stability and resilience. The application now gracefully manages errors that occur during API data processing instead of crashing, preventing unexpected failures and delivering a more reliable user experience when accessing content and metadata information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->