### PR TITLE
Include next airing episode in anime schedule data

### DIFF
--- a/crates/providers/anilist/src/models.rs
+++ b/crates/providers/anilist/src/models.rs
@@ -514,10 +514,12 @@ pub async fn media_details(client: &Client, id: &str) -> Result<MetadataDetails>
         && let Some(airing_at) = DateTimeUtc::from_timestamp(data.airing_at, 0)
     {
         let airing_at = airing_at.naive_utc();
-        if !airing_schedule
-            .iter()
-            .any(|s| s.episode == data.episode && s.airing_at == airing_at)
+        if let Some(existing) = airing_schedule
+            .iter_mut()
+            .find(|s| s.episode == data.episode)
         {
+            existing.airing_at = airing_at;
+        } else {
             airing_schedule.push(AnimeAiringScheduleSpecifics {
                 airing_at,
                 episode: data.episode,


### PR DESCRIPTION
Enhance the anime schedule data by merging the next airing episode into the existing airing schedule. This ensures that upcoming episodes are always captured, addressing issues with outdated airing schedule nodes.

Fixes #1702.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added next airing episode details to media pages.
  * Enhanced airing schedule assembly to include predicted/updated upcoming entries.
  * Expanded media retrieval to surface type, genres, studios, trailer, banner, volumes and average score.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->