### PR TITLE
Add autofocus attribute to submit button (mark as seen)

### DIFF
--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/new-progress-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/new-progress-form.tsx
@@ -193,8 +193,8 @@ export const MetadataNewProgressUpdateForm = (
 				<Button
 					size="xs"
 					type="submit"
-					variant="outline"
 					data-autofocus
+					variant="outline"
 					className={OnboardingTourStepTarget.AddAudiobookToWatchedHistory}
 					loading={deployBulkMetadataProgressUpdate.isPending}
 				>

--- a/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/new-progress-form.tsx
+++ b/apps/frontend/app/components/routes/dashboard/forms/metadata-progress-update/new-progress-form.tsx
@@ -194,6 +194,7 @@ export const MetadataNewProgressUpdateForm = (
 					size="xs"
 					type="submit"
 					variant="outline"
+					data-autofocus
 					className={OnboardingTourStepTarget.AddAudiobookToWatchedHistory}
 					loading={deployBulkMetadataProgressUpdate.isPending}
 				>


### PR DESCRIPTION
In "mark as seen" modal focus is not explicitly defined, and because of that the browser picks the first focusable element as default. From user standpoint it looks like if first element is dropdown (it usually is a season), it immediately opens. Very annoying considering mark as seen for TV shows almost always implies the currently selected episode not the different season's episode.

This fixes it by shifting focus explicitly to submit button.

Before:
<img width="548" height="526" alt="image" src="https://github.com/user-attachments/assets/5913e0de-1ad4-44c3-95a1-5b6d6ab176c6" />

After:
<img width="561" height="540" alt="image" src="https://github.com/user-attachments/assets/e6d47a92-9dbe-4ee6-b2fb-400db2256db5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Progress update form submit button now receives autofocus when the form loads, improving keyboard navigation and reducing the number of interactions required to submit updates. This enhances accessibility and speeds up the workflow for users who rely on keyboard input or assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->