### PR TITLE
Improve display of Template and Workout names in Desktop and Mobile Views

### DIFF
--- a/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
+++ b/apps/frontend/app/routes/_dashboard.fitness.$entity.list.tsx
@@ -28,8 +28,9 @@ import {
 	UserWorkoutTemplatesListDocument,
 	type WorkoutSummary,
 } from "@ryot/generated/graphql/backend/graphql";
-import { changeCase, humanizeDuration, truncate } from "@ryot/ts-utils";
+import { changeCase, humanizeDuration } from "@ryot/ts-utils";
 import {
+	IconCalendar,
 	IconCheck,
 	IconChevronDown,
 	IconChevronUp,
@@ -408,6 +409,7 @@ const DisplayFitnessEntity = (props: {
 					<Box>
 						<Group wrap="nowrap">
 							<Anchor
+								lineClamp={1}
 								component={Link}
 								fz={{ base: "sm", md: "md" }}
 								to={$path("/fitness/:entity/:id", {
@@ -415,13 +417,14 @@ const DisplayFitnessEntity = (props: {
 									entity: props.entity,
 								})}
 							>
-								{truncate(entityInformation.name, { length: 20 })}
+								{entityInformation.name}
 							</Anchor>
-							<Text fz={{ base: "xs", md: "sm" }} c="dimmed">
-								{dayjsLib(entityInformation.timestamp).format("dddd, LL")}
-							</Text>
 						</Group>
 						<Group mt="xs">
+							<DisplayStat
+								icon={<IconCalendar size={16} />}
+								data={dayjsLib(entityInformation.timestamp).format("dddd, LL")}
+							/>
 							<DisplayStat
 								data={entityInformation.detail}
 								icon={match(props.entity)


### PR DESCRIPTION
The changes enhance the visibility of Template and Workout names by removing truncation, allowing full names to be displayed in both Desktop and Mobile views. This addresses the issue of distinguishing between different Workouts and Templates, which was previously hindered by excessive truncation.

Fixes #1727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fitness entity names now display in full without truncation, constrained to a single line
  * Timestamp presentation updated with calendar icon and formatted date, integrated into the entity statistics display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->