### PR TITLE
Make workout template comments editable

### DIFF
--- a/apps/frontend/app/components/routes/fitness.action/miscellaneous.tsx
+++ b/apps/frontend/app/components/routes/fitness.action/miscellaneous.tsx
@@ -50,7 +50,7 @@ export const NameAndOtherInputs = (props: {
 
 	const [name, setName] = useDebouncedState(currentWorkout.name, 500);
 	const [comment, setComment] = useDebouncedState(currentWorkout.comment, 500);
-	const [isCaloriesBurntModalOpen, setIsCaloriesBurntModalOpen] =
+	const [isExtraInformationModalOpen, setIsExtraInformationModalOpen] =
 		useState(false);
 	const [caloriesBurnt, setCaloriesBurnt] = useDebouncedState(
 		currentWorkout.caloriesBurnt,
@@ -87,8 +87,8 @@ export const NameAndOtherInputs = (props: {
 		<>
 			<Modal
 				title="Additional details"
-				opened={isCaloriesBurntModalOpen}
-				onClose={() => setIsCaloriesBurntModalOpen(false)}
+				opened={isExtraInformationModalOpen}
+				onClose={() => setIsExtraInformationModalOpen(false)}
 			>
 				<Stack gap="xs">
 					{!props.isCreatingTemplate ? (
@@ -130,7 +130,10 @@ export const NameAndOtherInputs = (props: {
 				label={
 					<Group justify="space-between" mr="xs">
 						<Text size="sm">Name</Text>
-						<Anchor size="xs" onClick={() => setIsCaloriesBurntModalOpen(true)}>
+						<Anchor
+							size="xs"
+							onClick={() => setIsExtraInformationModalOpen(true)}
+						>
 							More Information
 						</Anchor>
 					</Group>

--- a/apps/frontend/app/components/routes/fitness.action/miscellaneous.tsx
+++ b/apps/frontend/app/components/routes/fitness.action/miscellaneous.tsx
@@ -91,19 +91,25 @@ export const NameAndOtherInputs = (props: {
 				onClose={() => setIsCaloriesBurntModalOpen(false)}
 			>
 				<Stack gap="xs">
-					<NumberInput
-						size="sm"
-						value={currentWorkout.caloriesBurnt}
-						label={`Energy burnt in ${userPreferences.fitness.logging.caloriesBurntUnit}`}
-						onChange={(e) => setCaloriesBurnt(isNumber(e) ? e : undefined)}
-					/>
+					{!props.isCreatingTemplate ? (
+						<NumberInput
+							size="sm"
+							value={currentWorkout.caloriesBurnt}
+							label={`Energy burnt in ${userPreferences.fitness.logging.caloriesBurntUnit}`}
+							onChange={(e) => setCaloriesBurnt(isNumber(e) ? e : undefined)}
+						/>
+					) : null}
 					<Textarea
 						size="sm"
 						minRows={2}
 						label="Comments"
 						defaultValue={comment}
-						placeholder="Your thoughts about this workout"
 						onChange={(e) => setComment(e.currentTarget.value)}
+						placeholder={
+							props.isCreatingTemplate
+								? "Notes or description for this template"
+								: "Your thoughts about this workout"
+						}
 					/>
 				</Stack>
 			</Modal>
@@ -124,14 +130,9 @@ export const NameAndOtherInputs = (props: {
 				label={
 					<Group justify="space-between" mr="xs">
 						<Text size="sm">Name</Text>
-						{!props.isCreatingTemplate ? (
-							<Anchor
-								size="xs"
-								onClick={() => setIsCaloriesBurntModalOpen(true)}
-							>
-								More Information
-							</Anchor>
-						) : null}
+						<Anchor size="xs" onClick={() => setIsCaloriesBurntModalOpen(true)}>
+							More Information
+						</Anchor>
 					</Group>
 				}
 			/>


### PR DESCRIPTION
Enable direct editing of comments in workout templates, simplifying the user experience by removing the need to create a new workout to modify comments. This change addresses the issue of cumbersome comment management in workout templates.

Fixes #1728

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hide calories input when creating templates to prevent irrelevant fields.

* **Improvements**
  * "Additional details" link is always visible and opens a consolidated modal.
  * Modal content and the free-text placeholder now adapt to whether a template is being created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->