### PR TITLE
Fix OIDC authentication with internal CA and improve job storage type clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6351,6 +6351,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.35",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ regex = "=1.12.3"
 reqwest = { version = "=0.12.25", features = [
     "json",
     "stream",
-    "rustls-tls",
+    "rustls-tls-native-roots",
 ], default-features = false }
 rstest = "=0.26.1"
 rust_decimal = { version = "=1.40.0", features = ["macros"] }

--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -52,7 +52,9 @@ static BASE_DIR: &str = env!("CARGO_MANIFEST_DIR");
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-fn make_job_storage<T: Send + 'static>() -> (Arc<Mutex<Option<MemoryStorage<T>>>>, JobStorage<T>) {
+type JobStoragePair<T> = (Arc<Mutex<Option<MemoryStorage<T>>>>, JobStorage<T>);
+
+fn make_job_storage<T: Send + 'static>() -> JobStoragePair<T> {
     let (sender, receiver) = unbounded();
     let sender = Box::new(sender);
     let sender = MemorySink::new(Arc::new(FuturesMutex::new(sender)));


### PR DESCRIPTION
Update the `reqwest` dependency to use `rustls-tls-native-roots` for proper certificate verification with internal CAs, resolving OIDC authentication issues. Additionally, refactor the job storage function to define a clearer type alias for improved code readability.

Fixes #1740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP client's TLS certificate validation backend for enhanced compatibility
  * Refactored internal code organization for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->