### PR TITLE
Fix jemalloc support for RPI5 and unsupported system page size

### DIFF
--- a/apps/backend/src/main.rs
+++ b/apps/backend/src/main.rs
@@ -25,7 +25,7 @@ use schematic::schema::{SchemaGenerator, TypeScriptRenderer, YamlTemplateRendere
 use sea_orm::{ConnectionTrait, Database, DatabaseConnection};
 use sea_orm_migration::MigratorTrait;
 use supporting_service::JobStorage;
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(not(target_env = "msvc"), target_arch = "x86_64"))]
 use tikv_jemallocator::Jemalloc;
 use tokio::{
     join,
@@ -48,7 +48,7 @@ mod job;
 static LOGGING_ENV_VAR: &str = "RUST_LOG";
 static BASE_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
-#[cfg(not(target_env = "msvc"))]
+#[cfg(all(not(target_env = "msvc"), target_arch = "x86_64"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
Adjust the configuration to ensure jemalloc is only used on x86_64 architectures, addressing the unsupported system page size issue on RPI5.

Fixes #1747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined conditional compilation configuration for memory allocator to target specific architectures, improving platform compatibility during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->