### PR TITLE
Upsert calendar events and propagate database errors in background jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,6 +4764,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "media-models",
+ "nanoid",
  "rust_decimal",
  "sea-orm",
  "serde",

--- a/crates/services/miscellaneous/background/Cargo.toml
+++ b/crates/services/miscellaneous/background/Cargo.toml
@@ -9,6 +9,7 @@ chrono = { workspace = true }
 convert_case = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
+nanoid = { workspace = true }
 rust_decimal = { workspace = true }
 sea-orm = { workspace = true }
 serde = { workspace = true }

--- a/crates/services/miscellaneous/background/src/calendar.rs
+++ b/crates/services/miscellaneous/background/src/calendar.rs
@@ -20,7 +20,10 @@ use itertools::Itertools;
 use media_models::{
     SeenAnimeExtraInformation, SeenPodcastExtraInformation, SeenShowExtraInformation,
 };
-use sea_orm::{ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, ModelTrait, QueryFilter};
+use nanoid::nanoid;
+use sea_orm::{
+    ActiveValue, ColumnTrait, EntityTrait, ModelTrait, QueryFilter, sea_query::OnConflict,
+};
 use serde::{Deserialize, Serialize};
 use supporting_service::SupportingService;
 
@@ -159,9 +162,23 @@ pub async fn recalculate_calendar_events(ss: &Arc<SupportingService>) -> Result<
         };
         metadata_updates.push(meta.id.clone());
     }
-    for cal_insert in calendar_events_inserts {
+    for mut cal_insert in calendar_events_inserts {
+        cal_insert.id = ActiveValue::Set(format!("cal_{}", nanoid!(12)));
         ryot_log!(debug, "Inserting calendar event: {:?}", cal_insert);
-        cal_insert.insert(&ss.db).await.ok();
+        CalendarEvent::insert(cal_insert)
+            .on_conflict(
+                OnConflict::columns([
+                    calendar_event::Column::Timestamp,
+                    calendar_event::Column::MetadataId,
+                    calendar_event::Column::MetadataShowExtraInformation,
+                    calendar_event::Column::MetadataPodcastExtraInformation,
+                    calendar_event::Column::MetadataAnimeExtraInformation,
+                ])
+                .do_nothing()
+                .to_owned(),
+            )
+            .exec_without_returning(&ss.db)
+            .await?;
     }
     ryot_log!(debug, "Finished updating calendar events");
     Ok(())

--- a/crates/services/miscellaneous/background/src/monitoring.rs
+++ b/crates/services/miscellaneous/background/src/monitoring.rs
@@ -56,7 +56,11 @@ pub async fn update_all_monitored_metadata_and_notify_users(
         let promises = chunk
             .into_iter()
             .map(|m| update_metadata_and_notify_users(m, ss));
-        join_all(promises).await;
+        for result in join_all(promises).await {
+            if let Err(e) = result {
+                ryot_log!(warn, "Monitored metadata update failed: {:?}", e);
+            }
+        }
     }
     Ok(())
 }
@@ -79,7 +83,11 @@ pub async fn update_all_monitored_people_and_notify_users(
         let promises = chunk
             .into_iter()
             .map(|p| update_person_and_notify_users(p, ss));
-        join_all(promises).await;
+        for result in join_all(promises).await {
+            if let Err(e) = result {
+                ryot_log!(warn, "Monitored person update failed: {:?}", e);
+            }
+        }
     }
     Ok(())
 }

--- a/crates/utils/dependent/entity/src/lib.rs
+++ b/crates/utils/dependent/entity/src/lib.rs
@@ -91,8 +91,7 @@ pub async fn commit_metadata(
         .filter(metadata::Column::Lot.eq(data.lot))
         .filter(metadata::Column::Source.eq(data.source))
         .one(&ss.db)
-        .await
-        .unwrap()
+        .await?
     {
         Some(c) => c,
         None => {
@@ -116,7 +115,10 @@ pub async fn commit_metadata(
     let was_updated_successfully = ensure_metadata_updated(&mode.id, ss, ensure_updated).await?;
 
     let final_metadata = match (was_updated_successfully, ensure_updated) {
-        (true, Some(true)) => Metadata::find_by_id(&mode.id).one(&ss.db).await?.unwrap(),
+        (true, Some(true)) => Metadata::find_by_id(&mode.id)
+            .one(&ss.db)
+            .await?
+            .ok_or_else(|| anyhow!("Metadata {} not found after ensure_updated", mode.id))?,
         _ => mode,
     };
 
@@ -416,9 +418,8 @@ pub async fn update_metadata(
 ) -> Result<UpdateMediaEntityResult> {
     let meta = Metadata::find_by_id(metadata_id)
         .one(&ss.db)
-        .await
-        .unwrap()
-        .unwrap();
+        .await?
+        .ok_or_else(|| anyhow!("Metadata {} not found", metadata_id))?;
     if !meta.is_partial.unwrap_or_default() {
         return Ok(UpdateMediaEntityResult::default());
     }
@@ -463,7 +464,7 @@ pub async fn update_metadata(
             meta.video_game_specifics = ActiveValue::Set(details.video_game_specifics);
             meta.external_identifiers = ActiveValue::Set(details.external_identifiers);
             meta.visual_novel_specifics = ActiveValue::Set(details.visual_novel_specifics);
-            let metadata = meta.update(&ss.db).await.unwrap();
+            let metadata = meta.update(&ss.db).await?;
 
             change_metadata_associations(
                 &metadata.id,
@@ -521,14 +522,13 @@ pub async fn update_metadata_group(
             .filter(metadata_to_metadata_group::Column::MetadataGroupId.eq(&eg.id))
             .filter(metadata_to_metadata_group::Column::MetadataId.eq(&db_partial_metadata.id))
             .exec(&ss.db)
-            .await
-            .ok();
+            .await?;
         let intermediate = metadata_to_metadata_group::ActiveModel {
             metadata_group_id: ActiveValue::Set(eg.id.clone()),
             metadata_id: ActiveValue::Set(db_partial_metadata.id),
             part: ActiveValue::Set(Some((idx + 1).try_into().unwrap())),
         };
-        intermediate.insert(&ss.db).await.ok();
+        intermediate.insert(&ss.db).await?;
     }
     expire_metadata_group_details_cache(metadata_group_id, ss).await?;
     Ok(UpdateMediaEntityResult::default())
@@ -541,7 +541,7 @@ pub async fn update_person(
     let person = Person::find_by_id(person_id.clone())
         .one(&ss.db)
         .await?
-        .unwrap();
+        .ok_or_else(|| anyhow!("Person {} not found", person_id))?;
     if !person.is_partial.unwrap_or_default() {
         return Ok(UpdateMediaEntityResult::default());
     }
@@ -588,7 +588,7 @@ pub async fn update_person(
                 character: ActiveValue::Set(data.character.clone()),
                 ..Default::default()
             };
-            intermediate.insert(&ss.db).await.unwrap();
+            intermediate.insert(&ss.db).await?;
         }
         let search_for = MediaAssociatedPersonStateChanges {
             role: data.role.clone(),
@@ -670,7 +670,7 @@ pub async fn update_person(
         }
     }
     to_update_person.state_changes = ActiveValue::Set(Some(current_state_changes));
-    to_update_person.update(&ss.db).await.unwrap();
+    to_update_person.update(&ss.db).await?;
     expire_person_details_cache(&person_id, ss).await?;
     Ok(UpdateMediaEntityResult { notifications })
 }


### PR DESCRIPTION
## Summary

`recalculate_calendar_events` was re-INSERTing every calendar event on every run without conflict semantics. Each attempted duplicate burned a database round-trip and rolled back its implicit transaction; at scale (hundreds of metadata rows touched by the monitoring cascade per nightly run) the resulting burst saturated the SeaORM connection pool. `.unwrap()` sites in `entity/src/lib.rs` then turned the resulting `ConnectionAcquire(Timeout)` and related missing-row races into thread panics.

The fix switches the calendar-event insert to `INSERT ... ON CONFLICT DO NOTHING` on the columns of the existing unique index and assigns the `cal_{nanoid}` primary key inline, because `Entity::insert(active_model)` bypasses the `ActiveModelBehavior::before_save` hook that the old `ActiveModel::insert()` call path invoked. The `.await.ok()` on the calendar insert is replaced with `.await?` so non-conflict errors no longer disappear silently. In `entity/src/lib.rs`, nine peer `.unwrap()` / silent-`.ok()` sites in the same `perform_background_jobs` call path — covering `commit_metadata`, `update_metadata`, `update_metadata_group`, and `update_person` — are converted to `?` or `ok_or_else(|| anyhow!(...))?`. Every enclosing function already returns `Result`. To keep those propagated errors visible, both monitoring chunk loops now iterate `join_all` results and log each `Err` at `warn` level instead of discarding every per-task `Result` silently.

Fixes #1750

## Scope

- `crates/services/miscellaneous/background/src/calendar.rs` — `on_conflict(do_nothing)` insert + inline `cal_{nanoid}` id assignment + `.await.ok()` → `.await?`.
- `crates/services/miscellaneous/background/Cargo.toml` — workspace `nanoid` dep.
- `crates/services/miscellaneous/background/src/monitoring.rs` — `warn`-level error logging in both `update_all_monitored_*_and_notify_users` chunk loops.
- `crates/utils/dependent/entity/src/lib.rs` — nine `.unwrap()` / `.ok()` replacements across `commit_metadata`, `update_metadata`, `update_metadata_group`, and `update_person`.

## Verification

Verified against a full-scale PostgreSQL 16 restore of a real ryot instance. Pre-fix binary (`ignisda/ryot:v10.3.8`): thousands of `duplicate key value violates unique constraint "calendar_event-date-metadataid-info__uq-idx"` errors per run, matching `xact_rollback` counter growth, with worker panics under sustained load. Post-fix binary (this branch): zero duplicate-key errors, zero rollback delta, zero panics across two consecutive dispatches. Table row count unchanged, confirming idempotency.

Pre-PR checks (from `AGENTS.md`):

- [x] `cargo clippy` (full workspace)
- [x] `yarn turbo run typecheck`
- [x] `yarn turbo run build --filter=@ryot/docs`
- [x] `cargo build --release`
- [x] `yarn turbo run test --filter=@ryot/tests` (4 files, 41 tests)

## Not addressed here

- `commit_metadata` / `commit_person` parallel-race (TOCTOU under the monitoring chunk size).
- `BULK_APPLICATION_UPDATE_CHUNK_SIZE` tuning.
- Converting the per-row calendar insert to `insert_many` (Postgres bind-parameter limit requires chunking logic beyond what this fix needs).
- The user-facing `generic_metadata` unwrap (different code path — request-time resolvers — distinct failure class).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in background services to report failures instead of silently suppressing them.
  * Calendar events now properly detect and handle conflicts during insertion.
  * Monitoring functions provide error visibility for failed operations.

* **Chores**
  * Added dependency for unique ID generation in background services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->