### PR TITLE
Refactor providersConsumedOn to filter out falsy values

### DIFF
--- a/apps/frontend/app/components/routes/media-item/modals/edit-history-modal.tsx
+++ b/apps/frontend/app/components/routes/media-item/modals/edit-history-modal.tsx
@@ -55,6 +55,9 @@ export const EditHistoryItemModal = (props: {
 	const [selectedSeasonNumber, setSelectedSeasonNumber] = useState<
 		number | null
 	>(props.seen.showExtraInformation?.season ?? null);
+	const [selectedProviders, setSelectedProviders] = useState<string[]>(
+		props.seen.providersConsumedOn || [],
+	);
 
 	const manualTimeSpentInSeconds =
 		convertDurationToSeconds(manualTimeSpentValue);
@@ -188,16 +191,23 @@ export const EditHistoryItemModal = (props: {
 							}
 						/>
 					) : null}
-					<MultiSelect
-						data={watchProviders}
-						name="providersConsumedOn"
-						defaultValue={props.seen.providersConsumedOn || []}
-						nothingFoundMessage="No watch providers configured. Please add them in your general preferences."
-						label={`Where did you ${getVerb(
-							Verb.Read,
-							metadataDetails.lot,
-						)} it?`}
-					/>
+				<MultiSelect
+					data={watchProviders}
+					value={selectedProviders}
+					onChange={setSelectedProviders}
+					nothingFoundMessage="No watch providers configured. Please add them in your general preferences."
+					label={`Where did you ${getVerb(
+						Verb.Read,
+						metadataDetails.lot,
+					)} it?`}
+				/>
+				{selectedProviders.length > 0 ? (
+					selectedProviders.map((p) => (
+						<input key={p} hidden readOnly name="providersConsumedOn" value={p} />
+					))
+				) : (
+					<input hidden readOnly name="providersConsumedOn" value="" />
+				)}
 					<Tooltip
 						label={PRO_REQUIRED_MESSAGE}
 						disabled={coreDetails.isServerKeyValidated}

--- a/apps/frontend/app/routes/_dashboard.media.item.$id._index.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.item.$id._index.tsx
@@ -231,7 +231,7 @@ const editSeenItem = z.object({
 	showEpisodeNumber: z.coerce.number().optional(),
 	animeEpisodeNumber: z.coerce.number().optional(),
 	podcastEpisodeNumber: z.coerce.number().optional(),
-	providersConsumedOn: z.array(z.string()).optional(),
+	providersConsumedOn: z.array(z.string()).transform((a) => a.filter(Boolean)),
 });
 
 export default function Page() {


### PR DESCRIPTION
Update the `providersConsumedOn` field in the editSeenItem schema to filter out falsy values, ensuring only valid providers are processed. Adjust the EditHistoryItemModal to utilize the updated state management for selected providers.

Fixes #1752.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form validation and submission handling for the providers field in the edit history interface, ensuring incomplete entries are properly filtered during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->