### PR TITLE
Add dynamic web search hyperlink for media items

### DIFF
--- a/apps/frontend/app/components/media/menu-items.tsx
+++ b/apps/frontend/app/components/media/menu-items.tsx
@@ -4,6 +4,7 @@ import {
 	type EntityLot,
 	MarkEntityAsPartialDocument,
 } from "@ryot/generated/graphql/backend/graphql";
+import { IconSearch } from "@tabler/icons-react";
 import { useMutation } from "@tanstack/react-query";
 import {
 	useAddEntitiesToCollectionMutation,
@@ -59,6 +60,20 @@ export const ToggleMediaMonitorMenuItem = (props: {
 			}
 		>
 			{isMonitored ? "Stop" : "Start"} monitoring
+		</Menu.Item>
+	);
+};
+
+export const WebSearchMenuItem = (props: { title: string }) => {
+	return (
+		<Menu.Item
+			component="a"
+			target="_blank"
+			rel="noopener noreferrer"
+			leftSection={<IconSearch size={14} />}
+			href={`https://www.google.com/search?q=${encodeURIComponent(props.title)}`}
+		>
+			Search web
 		</Menu.Item>
 	);
 };

--- a/apps/frontend/app/components/routes/media-item/modals/edit-history-modal.tsx
+++ b/apps/frontend/app/components/routes/media-item/modals/edit-history-modal.tsx
@@ -191,23 +191,29 @@ export const EditHistoryItemModal = (props: {
 							}
 						/>
 					) : null}
-				<MultiSelect
-					data={watchProviders}
-					value={selectedProviders}
-					onChange={setSelectedProviders}
-					nothingFoundMessage="No watch providers configured. Please add them in your general preferences."
-					label={`Where did you ${getVerb(
-						Verb.Read,
-						metadataDetails.lot,
-					)} it?`}
-				/>
-				{selectedProviders.length > 0 ? (
-					selectedProviders.map((p) => (
-						<input key={p} hidden readOnly name="providersConsumedOn" value={p} />
-					))
-				) : (
-					<input hidden readOnly name="providersConsumedOn" value="" />
-				)}
+					<MultiSelect
+						data={watchProviders}
+						value={selectedProviders}
+						onChange={setSelectedProviders}
+						nothingFoundMessage="No watch providers configured. Please add them in your general preferences."
+						label={`Where did you ${getVerb(
+							Verb.Read,
+							metadataDetails.lot,
+						)} it?`}
+					/>
+					{selectedProviders.length > 0 ? (
+						selectedProviders.map((p) => (
+							<input
+								hidden
+								key={p}
+								readOnly
+								value={p}
+								name="providersConsumedOn"
+							/>
+						))
+					) : (
+						<input hidden readOnly name="providersConsumedOn" value="" />
+					)}
 					<Tooltip
 						label={PRO_REQUIRED_MESSAGE}
 						disabled={coreDetails.isServerKeyValidated}

--- a/apps/frontend/app/routes/_dashboard.media.groups.item.$id._index.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.groups.item.$id._index.tsx
@@ -36,6 +36,7 @@ import {
 import {
 	MarkEntityAsPartialMenuItem,
 	ToggleMediaMonitorMenuItem,
+	WebSearchMenuItem,
 } from "~/components/media/menu-items";
 import {
 	useMetadataGroupDetails,
@@ -207,6 +208,7 @@ export default function Page() {
 												entityLot={EntityLot.MetadataGroup}
 												entityId={loaderData.metadataGroupId}
 											/>
+											<WebSearchMenuItem title={title} />
 										</Menu.Dropdown>
 									</Menu>
 									{metadataGroupDetailsData.data && (

--- a/apps/frontend/app/routes/_dashboard.media.item.$id._index.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.item.$id._index.tsx
@@ -80,6 +80,7 @@ import {
 import {
 	MarkEntityAsPartialMenuItem,
 	ToggleMediaMonitorMenuItem,
+	WebSearchMenuItem,
 } from "~/components/media/menu-items";
 import {
 	JUST_WATCH_URL,
@@ -965,6 +966,7 @@ export default function Page() {
 													entityLot={EntityLot.Metadata}
 													entityId={loaderData.metadataId}
 												/>
+												<WebSearchMenuItem title={title} />
 											</Menu.Dropdown>
 										</Menu>
 										{metadataDetails.data && (

--- a/apps/frontend/app/routes/_dashboard.media.people.item.$id._index.tsx
+++ b/apps/frontend/app/routes/_dashboard.media.people.item.$id._index.tsx
@@ -42,6 +42,7 @@ import {
 import {
 	MarkEntityAsPartialMenuItem,
 	ToggleMediaMonitorMenuItem,
+	WebSearchMenuItem,
 } from "~/components/media/menu-items";
 import {
 	useMetadataGroupDetails,
@@ -342,6 +343,7 @@ export default function Page() {
 												entityLot={EntityLot.Person}
 												entityId={loaderData.personId}
 											/>
+											<WebSearchMenuItem title={title} />
 										</Menu.Dropdown>
 									</Menu>
 									{personDetails.data && (


### PR DESCRIPTION
Implement a new `WebSearchMenuItem` component that creates a hyperlink for web searches based on the media item name. This feature allows users to easily search for media items on platforms like IMDB without requiring ID mapping. The hyperlink is dynamically generated using the media item title. Additionally, refactor the `EditHistoryItemModal` to improve input handling.

Fixes #1756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web search functionality across media, groups, and people detail pages—users can now search the web for items directly from the "More actions" menu.

* **Refactor**
  * Reorganized form structure in the edit history modal for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->