### PR TITLE
Allow Jellyfin sink plugin to work with TVDB

### DIFF
--- a/apps/frontend/app/routes/_dashboard.settings.integrations.tsx
+++ b/apps/frontend/app/routes/_dashboard.settings.integrations.tsx
@@ -100,7 +100,9 @@ export const action = async ({ request }: Route.ActionArgs) => {
 			await serverGqlService.authenticatedRequest(
 				request,
 				CreateOrUpdateUserIntegrationDocument,
-				{ input: submission },
+				{
+					input: submission,
+				},
 			);
 
 			const isUpdate = Boolean(submission.integrationId);
@@ -607,6 +609,18 @@ const PROVIDER_CONFIGS: Record<IntegrationProvider, ProviderConfig> = {
 				description:
 					"If specified, only webhooks for this user will be processed. Leave empty to process webhooks for all users.",
 			},
+			{
+				type: "select",
+				notRequired: true,
+				label: "Metadata Provider",
+				name: "jellyfinSinkMetadataProvider",
+				description:
+					"The metadata provider used to match media. Defaults to TMDB.",
+				options: [
+					{ label: "TMDB", value: "tmdb" },
+					{ label: "TVDB", value: "tvdb" },
+				],
+			},
 		],
 	},
 	[IntegrationProvider.Kodi]: {
@@ -730,7 +744,9 @@ const ProviderField = (props: {
 					defaultValue={
 						props.field.name === "youtubeMusicTimezone" && !value
 							? Intl.DateTimeFormat().resolvedOptions().timeZone
-							: (value as string) || undefined
+							: props.field.name === "jellyfinSinkMetadataProvider" && !value
+								? "tmdb"
+								: (value as string) || undefined
 					}
 				/>
 			);

--- a/crates/models/media/src/integrations.rs
+++ b/crates/models/media/src/integrations.rs
@@ -78,6 +78,7 @@ pub struct IntegrationProviderSpecifics {
     pub plex_sink_username: Option<String>,
 
     pub jellyfin_sink_username: Option<String>,
+    pub jellyfin_sink_metadata_provider: Option<String>,
 
     pub audiobookshelf_token: Option<String>,
     pub audiobookshelf_base_url: Option<String>,

--- a/crates/services/integration/src/sink/jellyfin.rs
+++ b/crates/services/integration/src/sink/jellyfin.rs
@@ -22,6 +22,7 @@ mod models {
     #[serde(rename_all = "PascalCase")]
     pub struct JellyfinWebhookItemProviderIdsPayload {
         pub tmdb: Option<String>,
+        pub tvdb: Option<String>,
     }
     #[derive(Serialize, Deserialize, Debug, Clone)]
     #[serde(rename_all = "PascalCase")]
@@ -54,6 +55,7 @@ mod models {
 pub async fn sink_progress(
     payload: String,
     jellyfin_sink_username: Option<String>,
+    jellyfin_sink_metadata_provider: Option<String>,
 ) -> Result<Option<ImportResult>> {
     let payload = serde_json::from_str::<models::JellyfinWebhookPayload>(&payload)?;
     if let Some(jellyfin_sink_username) = jellyfin_sink_username
@@ -61,19 +63,41 @@ pub async fn sink_progress(
     {
         return Ok(None);
     }
-    let identifier = payload
-        .item
-        .provider_ids
-        .tmdb
-        .as_ref()
-        .or_else(|| {
-            payload
-                .series
+    let use_tvdb = jellyfin_sink_metadata_provider.as_deref() == Some("tvdb");
+    let (identifier, source) = match use_tvdb {
+        true => {
+            let id = payload
+                .item
+                .provider_ids
+                .tvdb
                 .as_ref()
-                .and_then(|s| s.provider_ids.tmdb.as_ref())
-        })
-        .ok_or_else(|| anyhow!("No TMDb ID associated with this media"))?
-        .clone();
+                .or_else(|| {
+                    payload
+                        .series
+                        .as_ref()
+                        .and_then(|s| s.provider_ids.tvdb.as_ref())
+                })
+                .ok_or_else(|| anyhow!("No TVDB ID associated with this media"))?
+                .clone();
+            (id, MediaSource::Tvdb)
+        }
+        false => {
+            let id = payload
+                .item
+                .provider_ids
+                .tmdb
+                .as_ref()
+                .or_else(|| {
+                    payload
+                        .series
+                        .as_ref()
+                        .and_then(|s| s.provider_ids.tmdb.as_ref())
+                })
+                .ok_or_else(|| anyhow!("No TMDb ID associated with this media"))?
+                .clone();
+            (id, MediaSource::Tmdb)
+        }
+    };
 
     let lot = match payload.item.item_type.as_str() {
         "Movie" => MediaLot::Movie,
@@ -104,8 +128,8 @@ pub async fn sink_progress(
     let result = ImportResult {
         completed: vec![ImportCompletedItem::Metadata(ImportOrExportMetadataItem {
             lot,
+            source,
             identifier,
-            source: MediaSource::Tmdb,
             seen_history: vec![seen_item],
             ..Default::default()
         })],

--- a/crates/services/integration/src/webhook_handler.rs
+++ b/crates/services/integration/src/webhook_handler.rs
@@ -139,7 +139,12 @@ pub async fn process_integration_webhook(
         IntegrationProvider::GenericJson => sink::generic_json::sink_progress(payload).await,
         IntegrationProvider::JellyfinSink => {
             let specifics = integration.clone().provider_specifics.unwrap();
-            sink::jellyfin::sink_progress(payload, specifics.jellyfin_sink_username).await
+            sink::jellyfin::sink_progress(
+                payload,
+                specifics.jellyfin_sink_username,
+                specifics.jellyfin_sink_metadata_provider,
+            )
+            .await
         }
         IntegrationProvider::PlexSink => {
             let specifics = integration.clone().provider_specifics.unwrap();

--- a/libs/generated/src/graphql/backend/graphql.ts
+++ b/libs/generated/src/graphql/backend/graphql.ts
@@ -1282,6 +1282,7 @@ export type IntegrationProviderSpecifics = {
   jellyfinPushBaseUrl?: Maybe<Scalars['String']['output']>;
   jellyfinPushPassword?: Maybe<Scalars['String']['output']>;
   jellyfinPushUsername?: Maybe<Scalars['String']['output']>;
+  jellyfinSinkMetadataProvider?: Maybe<Scalars['String']['output']>;
   jellyfinSinkUsername?: Maybe<Scalars['String']['output']>;
   komgaApiKey?: Maybe<Scalars['String']['output']>;
   komgaBaseUrl?: Maybe<Scalars['String']['output']>;
@@ -1311,6 +1312,7 @@ export type IntegrationSourceSpecificsInput = {
   jellyfinPushBaseUrl?: InputMaybe<Scalars['String']['input']>;
   jellyfinPushPassword?: InputMaybe<Scalars['String']['input']>;
   jellyfinPushUsername?: InputMaybe<Scalars['String']['input']>;
+  jellyfinSinkMetadataProvider?: InputMaybe<Scalars['String']['input']>;
   jellyfinSinkUsername?: InputMaybe<Scalars['String']['input']>;
   komgaApiKey?: InputMaybe<Scalars['String']['input']>;
   komgaBaseUrl?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
Enhance the Jellyfin sink plugin to support TVDB as a metadata provider alongside TMDB. This update introduces a new configuration option for selecting the metadata provider and modifies the sink progress function to handle TVDB identifiers appropriately.

Fixes #1763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Jellyfin sink integration configuration to support selecting between TMDB and TVDB as the metadata provider. Users can now choose their preferred metadata source when syncing media with Jellyfin, providing greater flexibility for metadata identification. TMDB is configured as the default option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IgnisDa/ryot/pull/1764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->