### PR TITLE
Fix non-shows watched glow in Calendar

### DIFF
--- a/apps/frontend/app/components/media/display-items.tsx
+++ b/apps/frontend/app/components/media/display-items.tsx
@@ -94,9 +94,19 @@ export const MetadataDisplayItem = (props: {
 			);
 			return (episodeProgress?.timesSeen ?? 0) > 0;
 		}
+		if (
+			metadataDetails &&
+			metadataDetails.lot !== MediaLot.Show &&
+			metadataDetails.lot !== MediaLot.Podcast &&
+			metadataDetails.lot !== MediaLot.Anime &&
+			metadataDetails.lot !== MediaLot.Manga
+		)
+			return completedHistory.length > 0;
 		return false;
 	}, [
+		metadataDetails,
 		userMetadataDetails,
+		completedHistory,
 		props.calendarEventShowInfo,
 		props.calendarEventPodcastInfo,
 	]);

--- a/apps/frontend/app/components/media/display-items.tsx
+++ b/apps/frontend/app/components/media/display-items.tsx
@@ -105,8 +105,8 @@ export const MetadataDisplayItem = (props: {
 		return false;
 	}, [
 		metadataDetails,
-		userMetadataDetails,
 		completedHistory,
+		userMetadataDetails,
 		props.calendarEventShowInfo,
 		props.calendarEventPodcastInfo,
 	]);


### PR DESCRIPTION
https://github.com/IgnisDa/ryot/pull/1729 only works for some types of content but not for all.
This should fix that inconsistency and glow also movies and other types of things in Calendar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of "watched" status for calendar events by using completion history for media types beyond shows, podcasts, anime, and manga. Existing watched behavior for serialized content (episodes) remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IgnisDa/ryot/pull/1770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->