### PR TITLE
Make green glow only in calendar

### DIFF
--- a/apps/frontend/app/components/media/display-items.tsx
+++ b/apps/frontend/app/components/media/display-items.tsx
@@ -34,6 +34,7 @@ export const MetadataDisplayItem = (props: {
 	additionalInformation?: string;
 	shouldHighlightNameIfInteracted?: boolean;
 	onImageClickBehavior?: () => Promise<void>;
+	isCalendarEvent?: boolean;
 	calendarEventShowInfo?: SeenShowExtraInformationPartFragment;
 	calendarEventPodcastInfo?: SeenPodcastExtraInformationPartFragment;
 }) => {
@@ -95,6 +96,7 @@ export const MetadataDisplayItem = (props: {
 			return (episodeProgress?.timesSeen ?? 0) > 0;
 		}
 		if (
+			props.isCalendarEvent &&
 			metadataDetails &&
 			metadataDetails.lot !== MediaLot.Show &&
 			metadataDetails.lot !== MediaLot.Podcast &&
@@ -104,6 +106,7 @@ export const MetadataDisplayItem = (props: {
 			return completedHistory.length > 0;
 		return false;
 	}, [
+		props.isCalendarEvent,
 		metadataDetails,
 		completedHistory,
 		userMetadataDetails,

--- a/apps/frontend/app/components/media/display-items.tsx
+++ b/apps/frontend/app/components/media/display-items.tsx
@@ -31,10 +31,10 @@ export const MetadataDisplayItem = (props: {
 	isFirstItem?: boolean;
 	imageClassName?: string;
 	centerElement?: ReactNode;
+	isCalendarEvent?: boolean;
 	additionalInformation?: string;
 	shouldHighlightNameIfInteracted?: boolean;
 	onImageClickBehavior?: () => Promise<void>;
-	isCalendarEvent?: boolean;
 	calendarEventShowInfo?: SeenShowExtraInformationPartFragment;
 	calendarEventPodcastInfo?: SeenPodcastExtraInformationPartFragment;
 }) => {
@@ -96,20 +96,20 @@ export const MetadataDisplayItem = (props: {
 			return (episodeProgress?.timesSeen ?? 0) > 0;
 		}
 		if (
-			props.isCalendarEvent &&
 			metadataDetails &&
+			props.isCalendarEvent &&
 			metadataDetails.lot !== MediaLot.Show &&
-			metadataDetails.lot !== MediaLot.Podcast &&
+			metadataDetails.lot !== MediaLot.Manga &&
 			metadataDetails.lot !== MediaLot.Anime &&
-			metadataDetails.lot !== MediaLot.Manga
+			metadataDetails.lot !== MediaLot.Podcast
 		)
 			return completedHistory.length > 0;
 		return false;
 	}, [
-		props.isCalendarEvent,
 		metadataDetails,
 		completedHistory,
 		userMetadataDetails,
+		props.isCalendarEvent,
 		props.calendarEventShowInfo,
 		props.calendarEventPodcastInfo,
 	]);

--- a/apps/frontend/app/routes/_dashboard.calendar.tsx
+++ b/apps/frontend/app/routes/_dashboard.calendar.tsx
@@ -118,9 +118,9 @@ const CalendarEventMetadata = (props: {
 
 	return (
 		<MetadataDisplayItem
+			isCalendarEvent
 			metadataId={props.item.metadataId}
 			additionalInformation={additionalInformation}
-			isCalendarEvent
 			calendarEventShowInfo={props.item.showExtraInformation ?? undefined}
 			calendarEventPodcastInfo={props.item.podcastExtraInformation ?? undefined}
 		/>

--- a/apps/frontend/app/routes/_dashboard.calendar.tsx
+++ b/apps/frontend/app/routes/_dashboard.calendar.tsx
@@ -120,6 +120,7 @@ const CalendarEventMetadata = (props: {
 		<MetadataDisplayItem
 			metadataId={props.item.metadataId}
 			additionalInformation={additionalInformation}
+			isCalendarEvent
 			calendarEventShowInfo={props.item.showExtraInformation ?? undefined}
 			calendarEventPodcastInfo={props.item.podcastExtraInformation ?? undefined}
 		/>


### PR DESCRIPTION
This fixes behavior described in https://github.com/IgnisDa/ryot/pull/1770#issuecomment-4504624807
This adds conditionals to only apply it on calendar and nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watched-state tracking for calendar event metadata so calendar items correctly reflect viewing history.
  * Ensured calendar-specific context is considered when determining and displaying watched/completed status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IgnisDa/ryot/pull/1772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->