### PR TITLE
Fix suggestion links never getting inserted

### DIFF
--- a/crates/utils/dependent/entity/src/lib.rs
+++ b/crates/utils/dependent/entity/src/lib.rs
@@ -200,6 +200,7 @@ pub async fn change_metadata_associations(
             ..Default::default()
         };
         MetadataToMetadata::insert(intermediate)
+            .on_conflict(OnConflict::new().do_nothing().to_owned())
             .exec_without_returning(&ss.db)
             .await?;
     }


### PR DESCRIPTION
Inserting duplicate suggestions causes silent crash instead of graceful handling (skip). When block crashes it fails the entry entire update what means entry never leaves is_partial state causing infinite reload state.

This fixes #1777  that was introduced in 0ae7a792ae7d3c058c7aa9f55f2dca2fb2ebe36d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate suggestion entries to prevent processing interruptions and allow graceful continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->