### PR TITLE
Trakt import aborts on a collection item with all-null ids

### DIFF
--- a/crates/services/importer/trakt/src/lib.rs
+++ b/crates/services/importer/trakt/src/lib.rs
@@ -304,8 +304,8 @@ fn process_item(i: &ListItemResponse) -> Result<ImportOrExportMetadataItem, Impo
     fn err(i: &ListItemResponse, msg: &str) -> ImportFailedItem {
         ImportFailedItem {
             identifier: format!("{i:#?}"),
-            step: ImportFailStep::ItemDetailsFromSource,
             error: Some(msg.to_owned()),
+            step: ImportFailStep::ItemDetailsFromSource,
             ..Default::default()
         }
     }
@@ -314,7 +314,7 @@ fn process_item(i: &ListItemResponse) -> Result<ImportOrExportMetadataItem, Impo
     } else if let Some(d) = i.show.as_ref() {
         (d.ids.trakt, d.ids.tmdb, MediaLot::Show)
     } else {
-        return Err(err(i, "Item is neither a movie or a show"));
+        return Err(err(i, "Item is neither a movie nor a show"));
     };
     let source_id = match source_id {
         Some(s) => s.to_string(),
@@ -323,8 +323,8 @@ fn process_item(i: &ListItemResponse) -> Result<ImportOrExportMetadataItem, Impo
     match identifier {
         Some(identifier) => Ok(ImportOrExportMetadataItem {
             lot,
-            source: MediaSource::Tmdb,
             source_id,
+            source: MediaSource::Tmdb,
             identifier: identifier.to_string(),
             ..Default::default()
         }),

--- a/crates/services/importer/trakt/src/lib.rs
+++ b/crates/services/importer/trakt/src/lib.rs
@@ -33,7 +33,7 @@ async fn fetch_json<T: serde::de::DeserializeOwned>(
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct Id {
-    trakt: u64,
+    trakt: Option<u64>,
     tmdb: Option<u64>,
 }
 
@@ -127,13 +127,15 @@ pub async fn import(input: DeployTraktImportInput, client_id: &str) -> Result<Im
                 fetch_json(&client, &format!("{url}/lists"), None).await?;
 
             for list in lists.iter_mut() {
-                let items: Vec<ListItemResponse> = fetch_json(
-                    &client,
-                    &format!("{}/lists/{}/items", url, list.ids.trakt),
-                    None,
-                )
-                .await?;
-                list.items = items;
+                if let Some(trakt_id) = list.ids.trakt {
+                    let items: Vec<ListItemResponse> = fetch_json(
+                        &client,
+                        &format!("{}/lists/{}/items", url, trakt_id),
+                        None,
+                    )
+                    .await?;
+                    list.items = items;
+                }
             }
             for list in ["watchlist", "favorites"] {
                 let items: Vec<ListItemResponse> =
@@ -299,31 +301,33 @@ pub async fn import(input: DeployTraktImportInput, client_id: &str) -> Result<Im
 }
 
 fn process_item(i: &ListItemResponse) -> Result<ImportOrExportMetadataItem, ImportFailedItem> {
+    fn err(i: &ListItemResponse, msg: &str) -> ImportFailedItem {
+        ImportFailedItem {
+            identifier: format!("{i:#?}"),
+            step: ImportFailStep::ItemDetailsFromSource,
+            error: Some(msg.to_owned()),
+            ..Default::default()
+        }
+    }
     let (source_id, identifier, lot) = if let Some(d) = i.movie.as_ref() {
         (d.ids.trakt, d.ids.tmdb, MediaLot::Movie)
     } else if let Some(d) = i.show.as_ref() {
         (d.ids.trakt, d.ids.tmdb, MediaLot::Show)
     } else {
-        return Err(ImportFailedItem {
-            identifier: format!("{i:#?}"),
-            step: ImportFailStep::ItemDetailsFromSource,
-            error: Some("Item is neither a movie or a show".to_owned()),
-            ..Default::default()
-        });
+        return Err(err(i, "Item is neither a movie or a show"));
+    };
+    let source_id = match source_id {
+        Some(s) => s.to_string(),
+        None => return Err(err(i, "Item does not have an associated Trakt id")),
     };
     match identifier {
         Some(identifier) => Ok(ImportOrExportMetadataItem {
             lot,
             source: MediaSource::Tmdb,
-            source_id: source_id.to_string(),
+            source_id,
             identifier: identifier.to_string(),
             ..Default::default()
         }),
-        None => Err(ImportFailedItem {
-            identifier: format!("{i:#?}"),
-            step: ImportFailStep::ItemDetailsFromSource,
-            error: Some("Item does not have an associated TMDB id".to_owned()),
-            ..Default::default()
-        }),
+        None => Err(err(i, "Item does not have an associated TMDB id")),
     }
 }


### PR DESCRIPTION
Fixes #1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing Trakt IDs during Trakt import operations.
  * Enhanced error messaging by explicitly failing metadata import when required Trakt identifiers are absent.
* **Refactor**
  * Updated the import flow to fetch and assign list items only when a Trakt ID is available, preventing unnecessary lookups and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->