### PR TITLE
fix: enforce integration ownership on updates

### DIFF
--- a/crates/services/user/src/integration_operations.rs
+++ b/crates/services/user/src/integration_operations.rs
@@ -59,25 +59,33 @@ pub async fn create_or_update_user_integration(
     if input.minimum_progress > input.maximum_progress {
         bail!("Minimum progress cannot be greater than maximum progress");
     }
-    let id = match input.integration_id {
-        None => ActiveValue::NotSet,
-        Some(id) => ActiveValue::Set(id),
+    let mut to_save = match input.integration_id {
+        None => integration::ActiveModel {
+            id: ActiveValue::NotSet,
+            user_id: ActiveValue::Set(user_id),
+            ..Default::default()
+        },
+        Some(id) => {
+            let existing = Integration::find_by_id(&id)
+                .one(&ss.db)
+                .await?
+                .ok_or_else(|| anyhow!("Integration with the given id does not exist"))?;
+            if existing.user_id != user_id {
+                bail!("Integration does not belong to the user");
+            }
+            existing.into()
+        }
     };
-    let to_insert = integration::ActiveModel {
-        id,
-        lot,
-        provider,
-        name: ActiveValue::Set(input.name),
-        user_id: ActiveValue::Set(user_id),
-        is_disabled: ActiveValue::Set(input.is_disabled),
-        extra_settings: ActiveValue::Set(input.extra_settings),
-        minimum_progress: ActiveValue::Set(input.minimum_progress),
-        maximum_progress: ActiveValue::Set(input.maximum_progress),
-        provider_specifics: ActiveValue::Set(input.provider_specifics),
-        sync_to_owned_collection: ActiveValue::Set(input.sync_to_owned_collection),
-        ..Default::default()
-    };
-    to_insert.save(&ss.db).await?;
+    to_save.lot = lot;
+    to_save.provider = provider;
+    to_save.name = ActiveValue::Set(input.name);
+    to_save.is_disabled = ActiveValue::Set(input.is_disabled);
+    to_save.extra_settings = ActiveValue::Set(input.extra_settings);
+    to_save.minimum_progress = ActiveValue::Set(input.minimum_progress);
+    to_save.maximum_progress = ActiveValue::Set(input.maximum_progress);
+    to_save.provider_specifics = ActiveValue::Set(input.provider_specifics);
+    to_save.sync_to_owned_collection = ActiveValue::Set(input.sync_to_owned_collection);
+    to_save.save(&ss.db).await?;
     Ok(true)
 }
 

--- a/tests/src/tests/user.test.ts
+++ b/tests/src/tests/user.test.ts
@@ -1,5 +1,7 @@
 import { faker } from "@faker-js/faker";
 import {
+	CreateOrUpdateUserIntegrationDocument,
+	IntegrationProvider,
 	ResetUserDocument,
 	UserDetailsDocument,
 	UserImportReportsDocument,
@@ -134,6 +136,72 @@ describe("User related tests", () => {
 	it("should have 0 measurements", async () => {
 		const measurements = await getUserMeasurementsList(url, userApiKey);
 		expect(measurements).toHaveLength(0);
+	});
+});
+
+describe("User integration authorization", () => {
+	const url = process.env.API_BASE_URL as string;
+
+	it("should reject updating another user's integration", async () => {
+		const client = getGraphqlClient(url);
+		const [ownerApiKey] = await registerTestUser(url);
+		const [attackerApiKey] = await registerTestUser(url);
+		const input = {
+			name: "Private Sonarr integration",
+			provider: IntegrationProvider.Sonarr,
+			extraSettings: { disableOnContinuousErrors: false },
+			providerSpecifics: {
+				sonarrApiKey: "owner-secret",
+				sonarrBaseUrl: "http://sonarr.local",
+			},
+		};
+
+		await client.request(
+			CreateOrUpdateUserIntegrationDocument,
+			{ input },
+			{ Authorization: `Bearer ${ownerApiKey}` },
+		);
+		const { userIntegrations } = await client.request(
+			UserIntegrationsDocument,
+			{},
+			{ Authorization: `Bearer ${ownerApiKey}` },
+		);
+		expect(userIntegrations).toHaveLength(1);
+
+		const integration = userIntegrations[0];
+		await expect(
+			client.request(
+				CreateOrUpdateUserIntegrationDocument,
+				{
+					input: {
+						...input,
+						integrationId: integration.id,
+						name: "Hijacked integration",
+						providerSpecifics: {
+							sonarrApiKey: "attacker-secret",
+							sonarrBaseUrl: "http://attacker.local",
+						},
+					},
+				},
+				{ Authorization: `Bearer ${attackerApiKey}` },
+			),
+		).rejects.toThrow("Integration does not belong to the user");
+
+		const { userIntegrations: ownerIntegrations } = await client.request(
+			UserIntegrationsDocument,
+			{},
+			{ Authorization: `Bearer ${ownerApiKey}` },
+		);
+		expect(ownerIntegrations).toMatchObject([
+			{ id: integration.id, name: "Private Sonarr integration" },
+		]);
+
+		const { userIntegrations: attackerIntegrations } = await client.request(
+			UserIntegrationsDocument,
+			{},
+			{ Authorization: `Bearer ${attackerApiKey}` },
+		);
+		expect(attackerIntegrations).toHaveLength(0);
 	});
 });
 

--- a/tests/src/tests/user.test.ts
+++ b/tests/src/tests/user.test.ts
@@ -193,7 +193,11 @@ describe("User integration authorization", () => {
 			{ Authorization: `Bearer ${ownerApiKey}` },
 		);
 		expect(ownerIntegrations).toMatchObject([
-			{ id: integration.id, name: "Private Sonarr integration" },
+			{
+				id: integration.id,
+				name: "Private Sonarr integration",
+				providerSpecifics: { sonarrApiKey: "owner-secret" },
+			},
 		]);
 
 		const { userIntegrations: attackerIntegrations } = await client.request(


### PR DESCRIPTION
Fixes the cross-tenant IDOR in createOrUpdateUserIntegration described by GHSA-cjxv-jj8g-vfvj.

Summary:
- Validate that an integration belongs to the authenticated user before updating it.
- Reuse the fetched integration model so user_id cannot be reassigned on the update path.
- Add an end-to-end regression test proving another user cannot hijack or overwrite the integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened user integration persistence so updates apply only to integrations owned by the authenticated user.
  * Added checks to reject updates when the provided integration ID doesn’t belong to the user, preventing ownership and data changes.
* **Tests**
  * Added coverage for “User integration authorization” to verify unauthorized integration update attempts fail and leave both users’ integrations unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->