### PR TITLE
Fix Plex sink username filtering

### DIFF
--- a/apps/docs/src/integrations/plex-sink.md
+++ b/apps/docs/src/integrations/plex-sink.md
@@ -9,9 +9,9 @@ Automatically add [Plex](https://www.plex.tv) show and movie plays to Ryot. It w
 work for all the media that have a valid TMDb ID attached to their metadata.
 
 1. Generate a slug in the integration settings page using the following settings:
-    - Username => Your Plex `Fullname`. If you have no `Fullname` specified in Plex,
-       fallback to your Plex `Username`. This will be used to filter webhooks for the
-       specified Plex account only.
+    - Username => The exact value Plex sends as `Account.title` in its webhook payload.
+       This is typically your Plex `Username`. This will be used to filter webhooks for
+       the specified Plex account only. Leave it empty to accept events from all users.
 2. In your Plex Webhooks settings, add a new webhook using the following settings:
     - Webhook Url => `<paste_url_copied>`
 

--- a/apps/frontend/app/routes/_dashboard.settings.integrations.tsx
+++ b/apps/frontend/app/routes/_dashboard.settings.integrations.tsx
@@ -482,6 +482,7 @@ const PROVIDER_CONFIGS: Record<IntegrationProvider, ProviderConfig> = {
 				notRequired: true,
 				label: "Username",
 				name: "plexSinkUsername",
+				description: "Must exactly match Account.title in Plex webhooks",
 			},
 		],
 	},

--- a/crates/services/integration/src/sink/plex.rs
+++ b/crates/services/integration/src/sink/plex.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
 use common_models::StringIdObject;
+use common_utils::ryot_log;
 use dependent_models::{ImportCompletedItem, ImportOrExportMetadataItem, ImportResult};
 use enum_models::{MediaLot, MediaSource};
 use media_models::ImportOrExportMetadataItemSeen;
@@ -97,15 +98,32 @@ pub async fn sink_progress(
 ) -> Result<Option<ImportResult>> {
     let payload = parse_payload(&payload)?;
 
-    if let Some(plex_user) = &plex_user
-        && *plex_user != payload.account.plex_user
+    let plex_user = plex_user
+        .as_deref()
+        .map(str::trim)
+        .filter(|u| !u.is_empty());
+    if let Some(plex_user) = plex_user
+        && plex_user != payload.account.plex_user
     {
+        ryot_log!(
+            debug,
+            "Ignoring Plex webhook for user {:?}; integration is configured for {:?}",
+            payload.account.plex_user,
+            plex_user
+        );
         return Ok(None);
     }
 
     match payload.event_type.as_str() {
         "media.scrobble" | "media.play" | "media.pause" | "media.resume" | "media.stop" => {}
-        _ => return Ok(None),
+        _ => {
+            ryot_log!(
+                debug,
+                "Ignoring unsupported Plex webhook event {:?}",
+                payload.event_type
+            );
+            return Ok(None);
+        }
     };
 
     let identifier = get_tmdb_identifier(&payload.metadata.guids)?;


### PR DESCRIPTION
## Summary
- treat blank or whitespace-only Plex Sink usernames as an unset optional filter
- log username mismatches and unsupported webhook event types instead of silently returning no update
- clarify in the integration UI and documentation that the configured value must match `Account.title`

## Root cause
The optional username form field preserves an empty value as an empty string. The sink treated that as an active filter, causing every Plex webhook to be rejected without explaining why. The documentation also instructed users to enter their Plex full name even though current payloads expose the matching value through `Account.title`, typically the Plex username.

## Verification
- `rustfmt --edition 2024 --check crates/services/integration/src/sink/plex.rs`
- `yarn turbo lint --filter=@ryot/frontend --filter=@ryot/docs`
- `yarn turbo build --filter=@ryot/frontend`
- `yarn turbo build --filter=@ryot/docs`

Fixes #1798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Plex Sink username matching now uses the exact `Account.title` value from Plex webhook payloads.
  - Leading or trailing spaces are ignored, and an empty username accepts events from all users.
  - Unsupported Plex webhook event types are handled gracefully.

- **Documentation**
  - Updated Plex integration setup instructions to clarify username requirements.

- **UI Improvements**
  - Added guidance to the Plex username field explaining the exact value required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->